### PR TITLE
Fix WAF image cookie handshake

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
@@ -48,6 +48,7 @@ import me.thenano.yamibo.yamibo_app.feedback.AppFeedbackDuration
 import me.thenano.yamibo.yamibo_app.feedback.AppFeedbackResult
 import me.thenano.yamibo.yamibo_app.event.AppEventBus
 import me.thenano.yamibo.yamibo_app.event.events.SignStatusChangedEvent
+import me.thenano.yamibo.yamibo_app.factory.HttpClientFactory
 import me.thenano.yamibo.yamibo_app.home.HomePageScreen
 import me.thenano.yamibo.yamibo_app.i18n.AppLocaleProvider
 import me.thenano.yamibo.yamibo_app.i18n.i18n
@@ -128,7 +129,9 @@ fun App() {
                         .build()
                 }
                 .components {
-                    add(KtorNetworkFetcherFactory())
+                    // Coil lazily retains this client for the singleton ImageLoader, allowing the
+                    // in-memory WAF cookie to be reused without another app-level singleton.
+                    add(KtorNetworkFetcherFactory(httpClient = { HttpClientFactory.create() }))
                     add(SvgDecoder.Factory())
                 }
                 .build()

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/util/ImageRequest.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/util/ImageRequest.kt
@@ -13,6 +13,12 @@ import coil3.size.Precision
 import io.github.littlesurvival.YamiboRoute
 import me.thenano.yamibo.yamibo_app.LocalAuthRepository
 
+/**
+ * Converts an image source into the URL or URI passed to Coil.
+ *
+ * Absolute network URLs and local `content://` or `file://` URIs are preserved. Relative forum
+ * attachment paths are resolved against [YamiboRoute.Domain].
+ */
 fun normalizeImageUrl(url: String): String {
     val cleaned = repairDomainPrefixedLocalUri(url)
     return if (cleaned.contains("://")) {
@@ -22,6 +28,13 @@ fun normalizeImageUrl(url: String): String {
     }
 }
 
+/**
+ * Restores a local URI that was accidentally prefixed with the Yamibo forum origin.
+ *
+ * For example, `https://bbs.yamibo.com/content://...` must become `content://...` before it is
+ * passed to Coil. Without this repair, Coil treats the value as an HTTP URL instead of a local
+ * content or file URI.
+ */
 private fun repairDomainPrefixedLocalUri(url: String): String {
     val domain = YamiboRoute.Domain.build().trimEnd('/')
     return when {
@@ -40,7 +53,7 @@ fun buildImageRequest(
     enableCrossfade: Boolean = true,
 ): ImageRequest {
     val fullUrl = normalizeImageUrl(url)
-    val isYamiboDomain = fullUrl.contains("yamibo.com")
+    val isYamiboDomain = fullUrl.startsWith(YamiboRoute.Domain.build())
 
     return ImageRequest.Builder(context)
         .data(fullUrl)

--- a/shared/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/factory/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/factory/HttpClientFactory.android.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import me.thenano.yamibo.yamibo_app.network.WafCookieHandshake
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual object HttpClientFactory {
@@ -22,6 +23,7 @@ actual object HttpClientFactory {
             socketTimeoutMillis = 30_000
             requestTimeoutMillis = 45_000
         }
+        install(WafCookieHandshake)
 
         install(ContentNegotiation) {
             json(

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/network/WafCookieHandshake.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/network/WafCookieHandshake.kt
@@ -1,0 +1,94 @@
+package me.thenano.yamibo.yamibo_app.network
+
+import io.ktor.client.plugins.api.Send
+import io.ktor.client.plugins.api.SendingRequest
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.plugins.cookies.AcceptAllCookiesStorage
+import io.ktor.client.plugins.cookies.CookiesStorage
+import io.ktor.http.Cookie
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+import io.ktor.http.parseClientCookiesHeader
+import io.ktor.http.parseServerSetCookieHeader
+import io.ktor.http.renderCookieHeader
+import io.github.littlesurvival.YamiboRoute
+
+private const val WAF_COOKIE_NAME = "abymg_id"
+
+/**
+ * Completes the Baidu image-WAF cookie handshake without taking ownership of the user's forum
+ * session cookies.
+ *
+ * The WAF can answer the first image request with a same-URL redirect and an `abymg_id` cookie.
+ * Ktor must save that cookie before following the redirect and add it to the next request, or the
+ * server repeats the redirect indefinitely. Ktor's standard `HttpCookies` plugin is intentionally
+ * not used here: it also captures the login cookie supplied by the image request and then replaces
+ * the request's complete `Cookie` header from its own storage. This plugin stores only `abymg_id`
+ * and merges it into the existing header instead.
+ *
+ * The storage is in memory and belongs to one `HttpClient`. Coil keeps its network client lazily for
+ * the lifetime of the singleton image loader, so the WAF cookie is reused by subsequent images while
+ * remaining isolated from unrelated hosts and application restarts.
+ */
+internal val WafCookieHandshake = createClientPlugin("WafCookieHandshake") {
+    val storage = WafCookieStorage()
+    val yamiboDomain = YamiboRoute.Domain.build()
+
+    on(SendingRequest) { request, _ ->
+        val requestUrl = request.url.build()
+        if (!requestUrl.toString().startsWith(yamiboDomain)) return@on
+
+        val wafCookies = storage.get(requestUrl)
+        if (wafCookies.isEmpty()) return@on
+
+        request.headers[HttpHeaders.Cookie] = mergeWafCookies(
+            existingHeader = request.headers[HttpHeaders.Cookie],
+            wafCookies = wafCookies,
+        )
+    }
+
+    on(Send) { request ->
+        val call = proceed(request)
+        if (call.request.url.toString().startsWith(yamiboDomain)) {
+            call.response.headers.getAll(HttpHeaders.SetCookie)
+                .orEmpty()
+                .mapNotNull { header -> runCatching { parseServerSetCookieHeader(header) }.getOrNull() }
+                .filter { cookie -> cookie.name == WAF_COOKIE_NAME }
+                .forEach { cookie -> storage.addCookie(call.request.url, cookie) }
+        }
+        call
+    }
+
+    onClose(storage::close)
+}
+
+/**
+ * Delegates expiry, path, domain, and secure-cookie matching to Ktor while rejecting every cookie
+ * except the WAF token. In particular, response cookies and the manually supplied forum login
+ * cookie must never accumulate in this client-owned storage.
+ */
+private class WafCookieStorage : CookiesStorage {
+    private val delegate = AcceptAllCookiesStorage()
+
+    override suspend fun get(requestUrl: Url): List<Cookie> = delegate.get(requestUrl)
+
+    override suspend fun addCookie(requestUrl: Url, cookie: Cookie) {
+        if (cookie.name == WAF_COOKIE_NAME) {
+            delegate.addCookie(requestUrl, cookie)
+        }
+    }
+
+    override fun close() {
+        delegate.close()
+    }
+}
+
+private fun mergeWafCookies(existingHeader: String?, wafCookies: List<Cookie>): String {
+    val existingCookies = existingHeader
+        ?.let(::parseClientCookiesHeader)
+        .orEmpty()
+        .filterKeys { name -> name != WAF_COOKIE_NAME }
+        .map { (name, value) -> "$name=$value" }
+
+    return (existingCookies + wafCookies.map(::renderCookieHeader)).joinToString("; ")
+}

--- a/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/network/WafCookieHandshakeTest.kt
+++ b/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/network/WafCookieHandshakeTest.kt
@@ -1,0 +1,72 @@
+package me.thenano.yamibo.yamibo_app.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WafCookieHandshakeTest {
+    @Test
+    fun storesOnlyWafCookieAndReplaysItThroughSelfRedirect() = runBlocking {
+        val requestCookies = mutableListOf<String?>()
+        var imageRequestCount = 0
+        val engine = MockEngine { request ->
+            requestCookies += request.headers[HttpHeaders.Cookie]
+            when (request.url.encodedPath) {
+                "/image.jpg" -> if (imageRequestCount++ == 0) {
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.Found,
+                        headers = headersOf(
+                            HttpHeaders.Location to listOf(request.url.toString()),
+                            HttpHeaders.SetCookie to listOf(
+                                "abymg_id=waf-cookie; Max-Age=86400; Domain=.yamibo.com; Path=/",
+                                "tracking=must-not-leak; Max-Age=86400; Domain=.yamibo.com; Path=/",
+                            ),
+                        ),
+                    )
+                } else {
+                    respond(content = "image")
+                }
+
+                "/other.jpg" -> respond(content = "other")
+                "/external.jpg" -> respond(content = "external")
+                else -> error("Unexpected request path: ${request.url.encodedPath}")
+            }
+        }
+        val client = HttpClient(engine) {
+            install(WafCookieHandshake)
+        }
+
+        try {
+            val image = client.get("https://bbs.yamibo.com/image.jpg") {
+                header(HttpHeaders.Cookie, "EeqY_2132_auth=auth-cookie")
+            }
+            val other = client.get("https://bbs.yamibo.com/other.jpg")
+            val external = client.get("https://cdn.example.com/external.jpg")
+
+            assertEquals("image", image.bodyAsText())
+            assertEquals("other", other.bodyAsText())
+            assertEquals("external", external.bodyAsText())
+            assertEquals(
+                listOf<String?>(
+                    "EeqY_2132_auth=auth-cookie",
+                    "EeqY_2132_auth=auth-cookie; abymg_id=waf-cookie",
+                    "abymg_id=waf-cookie",
+                    null,
+                ),
+                requestCookies,
+            )
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/factory/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/factory/HttpClientFactory.ios.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import me.thenano.yamibo.yamibo_app.network.WafCookieHandshake
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "unused")
 actual object HttpClientFactory {
@@ -16,6 +17,7 @@ actual object HttpClientFactory {
                 socketTimeoutMillis = 30_000
                 requestTimeoutMillis = 45_000
             }
+            install(WafCookieHandshake)
             install(ContentNegotiation) {
                 json(
                     Json {


### PR DESCRIPTION
## Summary

- Add a focused Ktor cookie-handshake plugin for Baidu WAF that stores and reuses only `abymg_id`
- Merge the WAF cookie immediately before each request and capture `Set-Cookie` before Ktor follows the redirect
- Install the plugin in the Android OkHttp and iOS Darwin `HttpClientFactory`
- Let Coil lazily retain the factory-created client used by its singleton `ImageLoader`; no additional app-level HTTP singleton
- Preserve existing login cookies without copying authentication or unrelated response cookies into WAF storage
- Add MockEngine regression coverage for the 302 self-redirect handshake, reuse on the Yamibo forum domain, and external-host isolation

## Root Cause

On the first static-resource request, Baidu WAF can return a 302 redirect to the same URL and issue an approximately 24-hour `abymg_id` cookie through `Set-Cookie`.

The previous image network stack did not retain and send that cookie before the next redirect hop. It therefore repeated the same 302 until Ktor exhausted its redirect limit.

Installing the default `HttpCookies` plugin would also absorb the manually supplied login cookie. This implementation deliberately manages only `abymg_id`, avoiding session-cookie retention and unrelated cookie accumulation.

## Verification

- `:shared:testDebugUnitTest --tests me.thenano.yamibo.yamibo_app.network.WafCookieHandshakeTest`
- `:composeApp:compileDebugKotlinAndroid`
- `:shared:compileKotlinIosSimulatorArm64`
- `:composeApp:compileKotlinIosSimulatorArm64`
- Fresh Coil disk-cache live image load succeeded on the available TPE/Cloudflare route
- `git diff --check`
- No `openspec/` changes

The available route does not expose the mainland Baidu-WAF 302 response, so that handshake is deterministically covered by MockEngine.

Fixes #17