### PR TITLE
fix(image): register SVG decoder so default forum avatars render

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
             implementation(libs.coil3.compose)
             implementation(libs.coil3.gif)
             implementation(libs.coil3.network.ktor3)
+            implementation(libs.coil3.svg)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.yamibo.api)
             implementation(libs.ksoup)

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
@@ -30,6 +30,7 @@ import coil3.PlatformContext
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.svg.SvgDecoder
 import io.github.littlesurvival.YamiboClient
 import io.github.littlesurvival.waf.YamiboWafChallengeHost
 import kotlinx.coroutines.coroutineScope
@@ -128,6 +129,7 @@ fun App() {
                 }
                 .components {
                     add(KtorNetworkFetcherFactory())
+                    add(SvgDecoder.Factory())
                 }
                 .build()
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 coil3-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
 coil3-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil3" }
 coil3-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil3" }
+coil3-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil3" }
 yamibo-api = { module = "io.github.littlesurvival:yamibo-api", version.ref = "yamiboApi" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }


### PR DESCRIPTION
fix(image): 注册 SVG 解码器，修复默认头像无法渲染

论坛对未设置自定义头像的用户返回默认头像 noavatar.svg（SVG 格式）。
Coil 3 未注册 SVG 解码器，图片下载成功（HTTP 200、已缓存）但解码失败，
落入 error slot，导致个人页及其他头像位置显示空白圆。

引入 coil-svg 依赖，并在单例 ImageLoader 注册 SvgDecoder.Factory()。
真机验证：个人页默认头像剪影已正常渲染。

<img width="540" height="1200" alt="2fcafcb4681a2139e3a85f8a3472c5c5" src="https://github.com/user-attachments/assets/48df1760-c015-4adb-a0d0-c9fc253de758" />


Closes #22 