### PR TITLE
Fix WebView loading overlay stuck on hanging sub-resource

### DIFF
--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/webview/PlatformWebView.android.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/webview/PlatformWebView.android.kt
@@ -59,6 +59,20 @@ actual fun PlatformWebViewContent(
                         onLoadingChanged(true)
                     }
 
+                    /**
+                     * Android invokes this callback when the new main-frame document has
+                     * committed and its next draw will no longer show content from the
+                     * previous page. This is the earliest semantic point at which the
+                     * modal loading overlay can be removed without relying on sub-resource
+                     * completion. onPageFinished remains responsible for cookie sync, HTML
+                     * capture, and the caller's completion callback because those operations
+                     * still require the full page-finished signal.
+                     */
+                    override fun onPageCommitVisible(view: WebView?, url: String?) {
+                        super.onPageCommitVisible(view, url)
+                        onLoadingChanged(false)
+                    }
+
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
                         onLoadingChanged(false)
@@ -110,18 +124,6 @@ actual fun PlatformWebViewContent(
                     }
                 }
                 webChromeClient = object : WebChromeClient() {
-                    override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                        super.onProgressChanged(view, newProgress)
-                        // Release the loading overlay as soon as the main document is
-                        // loaded. onPageFinished waits for every sub-resource and can be
-                        // stalled indefinitely by a hanging request (observed with
-                        // net::ERR_CONNECTION_TIMED_OUT), leaving the overlay stuck over an
-                        // already-usable page.
-                        if (newProgress >= 100) {
-                            onLoadingChanged(false)
-                        }
-                    }
-
                     override fun onReceivedTitle(view: WebView?, title: String?) {
                         super.onReceivedTitle(view, title)
                         title?.let { onTitleChanged(it) }

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/webview/PlatformWebView.android.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/webview/PlatformWebView.android.kt
@@ -110,6 +110,18 @@ actual fun PlatformWebViewContent(
                     }
                 }
                 webChromeClient = object : WebChromeClient() {
+                    override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                        super.onProgressChanged(view, newProgress)
+                        // Release the loading overlay as soon as the main document is
+                        // loaded. onPageFinished waits for every sub-resource and can be
+                        // stalled indefinitely by a hanging request (observed with
+                        // net::ERR_CONNECTION_TIMED_OUT), leaving the overlay stuck over an
+                        // already-usable page.
+                        if (newProgress >= 100) {
+                            onLoadingChanged(false)
+                        }
+                    }
+
                     override fun onReceivedTitle(view: WebView?, title: String?) {
                         super.onReceivedTitle(view, title)
                         title?.let { onTitleChanged(it) }


### PR DESCRIPTION
## 问题

登录 WebView 进入后，全屏模态 Loading 长时间不消失（实测 18~60s+，某些情况下永久卡住）。期间页面其实已经渲染可用，但被应用自己的 LoadingOverlay（92% 不透明 + 阻塞输入）盖住。

## 根因

- LoadingOverlay 的消失条件**只**绑定在 `onPageFinished`（iOS 为 `didFinishNavigation`）
- `onPageFinished` 要等页面**所有子资源**加载完（onload 语义），而页面上有挂起的网络请求（实测 logcat：`net::ERR_CONNECTION_TIMED_OUT`，30s 超时窗口）会永久推迟它
- 真机实测证据：`onProgressChanged 100`（主文档加载完成）已到达、chromium 日志 `content load finished`，但 `onPageFinished` 从未触发 → 遮罩永久盖着已渲染的页面

## 修复

`PlatformWebView.android.kt`：`onProgressChanged >= 100` 时调用 `onLoadingChanged(false)` 放行遮罩——主文档加载完成（页面可交互）即消失，不再等可能被挂起资源卡死的 `onPageFinished`。

```kotlin
webChromeClient = object : WebChromeClient() {
    override fun onProgressChanged(view: WebView?, newProgress: Int) {
        super.onProgressChanged(view, newProgress)
        if (newProgress >= 100) {
            onLoadingChanged(false)
        }
    }
    ...
}
```

如果页面始终不加载完成，用户可用系统返回键退出（不自动放行，保持现有交互）。

## 验证（真机 BRT-W09）

- logcat 确认：`onProgressChanged 100` 触发后遮罩放行
- 截图像素对比：修复前中心区域方差 1286（纯色遮罩），修复后 26666（页面内容可见）

## 变更

- `composeApp/src/androidMain/.../webview/PlatformWebView.android.kt`（+12 行）