### PR TITLE
feat: centralize download and backup folder settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 ## Branch naming isolation
 
 - Before creating any branch, read [Branch Naming Rule Document](dev-docs/branch-naming.md).
+- Do not prefix repository branch names with `codex/`; branch names must start directly with the version/lineage pattern defined in the branch naming document.
 
 ## Main branch integration
 

--- a/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/StorageFolderSettingsEntryContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/StorageFolderSettingsEntryContractTest.kt
@@ -1,0 +1,67 @@
+package me.thenano.yamibo.yamibo_app.profile.settings
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StorageFolderSettingsEntryContractTest {
+    @Test
+    fun storagePageOwnsTheSharedFolderPickerAndPersistence() {
+        val source = source("profile/settings/SettingsCategoryScreen.kt")
+        val settingsSource = source("profile/settings/SettingsScreen.kt")
+
+        assertTrue(settingsSource.contains("下載、備份資料夾與緩存清理設定"))
+        assertTrue(source.contains("rememberBackupFileActions("))
+        assertTrue(source.contains("backupRepository.setSelectedFolder(uri)"))
+        assertTrue(source.contains("SharedStorageFolderCard("))
+        assertTrue(source.contains("onSelectFolder = folderActions.selectFolder"))
+        assertTrue(source.contains("下載與備份資料夾"))
+        assertTrue(source.contains("下載內容與本地備份共用此資料夾"))
+        assertTrue(source.contains("if (folderLabel == null) \"選擇資料夾\" else \"變更資料夾\""))
+    }
+
+    @Test
+    fun backupPageLinksToStorageInsteadOfSelectingTheFolderDirectly() {
+        val source = source("profile/settings/backup/BackupSettingsScreen.kt")
+
+        assertTrue(source.contains("ISettingsCategoryScreen(\"storage\")"))
+        assertTrue(source.contains("onFolderSelected = {}"))
+        assertTrue(source.contains("前往儲存空間"))
+        assertFalse(source.contains("onClick = fileActions.selectFolder"))
+        assertFalse(source.contains("repository.setSelectedFolder(uri)"))
+    }
+
+    @Test
+    fun downloadPageAlwaysLinksItsFolderCardToStorage() {
+        val source = source("profile/download/DownloadQueueScreen.kt")
+
+        assertTrue(source.contains("navigator.navigate(ISettingsCategoryScreen(\"storage\"))"))
+        assertTrue(source.contains("item { DownloadFolderSettingsCard(folderReady, onOpenStorageSettings) }"))
+        assertTrue(source.contains("前往儲存空間"))
+        assertFalse(source.contains("IBackupSettingsScreen"))
+    }
+
+    @Test
+    fun missingDownloadFolderActionsLinkToStorageInsteadOfBackup() {
+        val downloadEntrySources = listOf(
+            "thread/reader/ThreadReaderScreen.kt",
+            "favorite/FavoritePage.kt",
+            "thread/detail/tag/TagDetailScreen.kt",
+            "thread/detail/rss/RssSearchSubscriptionDetailScreen.kt",
+        ).map(::source)
+
+        downloadEntrySources.forEach { source ->
+            assertTrue(source.contains("ISettingsCategoryScreen(\"storage\")"))
+            assertFalse(source.contains("IBackupSettingsScreen"))
+        }
+    }
+
+    private fun source(relativePath: String): String = repoRoot()
+        .resolve("composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/$relativePath")
+        .readText(Charsets.UTF_8)
+
+    private fun repoRoot(): File =
+        generateSequence(File(requireNotNull(System.getProperty("user.dir"))).absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePage.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePage.kt
@@ -34,7 +34,7 @@ import me.thenano.yamibo.yamibo_app.navigation.*
 import me.thenano.yamibo.yamibo_app.performance.favoriteHistoryLoadPerf
 import me.thenano.yamibo.yamibo_app.performance.LatestLoadGeneration
 import me.thenano.yamibo.yamibo_app.profile.settings.access.IBackgroundAccessSetupScreen
-import me.thenano.yamibo.yamibo_app.profile.settings.backup.IBackupSettingsScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
 import me.thenano.yamibo.yamibo_app.repository.FavoriteShareRepository
 import me.thenano.yamibo.yamibo_app.repository.FavoriteStoreRepository.*
 import me.thenano.yamibo.yamibo_app.repository.FavoriteSyncRepository.FavoriteSyncState
@@ -855,8 +855,8 @@ fun FavoritePage() {
                 ) {
                     try {
                         if (!downloadRepository.isStorageReady()) {
-                            showSnackbarMessage(i18n("請先設定備份資料夾"))
-                            navigator.navigate(IBackupSettingsScreen())
+                            showSnackbarMessage(i18n("尚未設定下載資料夾"))
+                            navigator.navigate(ISettingsCategoryScreen("storage"))
                             return@launch
                         }
                         val result = withContext(Dispatchers.Default) {

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/download/DownloadQueueScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/download/DownloadQueueScreen.kt
@@ -43,7 +43,7 @@ import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
 import me.thenano.yamibo.yamibo_app.core.cache.CacheStorageUsage
 import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
-import me.thenano.yamibo.yamibo_app.profile.settings.backup.IBackupSettingsScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
 import me.thenano.yamibo.yamibo_app.repository.DownloadRepository
 import me.thenano.yamibo.yamibo_app.repository.download.*
 import me.thenano.yamibo.yamibo_app.util.formatDownloadedByteSize
@@ -127,7 +127,7 @@ fun DownloadQueueScreen() {
                     entries = entries,
                     summary = summary,
                     folderReady = folderReady,
-                    onOpenSettings = { navigator.navigate(IBackupSettingsScreen()) },
+                    onOpenStorageSettings = { navigator.navigate(ISettingsCategoryScreen("storage")) },
                     onPauseAll = {
                         appTaskManager.launch(AppTaskKey("download-control:pause-all")) {
                             repository.pauseAll()
@@ -269,7 +269,7 @@ private fun DownloadQueueTab(
     entries: List<DownloadQueueEntry>,
     summary: DownloadQueueSummary,
     folderReady: Boolean,
-    onOpenSettings: () -> Unit,
+    onOpenStorageSettings: () -> Unit,
     onPauseAll: () -> Unit,
     onResumeAll: () -> Unit,
     onRetry: (DownloadQueueEntry) -> Unit,
@@ -288,9 +288,7 @@ private fun DownloadQueueTab(
                 onResumeAll = onResumeAll,
             )
         }
-        if (!folderReady) {
-            item { BackupFolderRequiredCard(onOpenSettings) }
-        }
+        item { DownloadFolderSettingsCard(folderReady, onOpenStorageSettings) }
         if (entries.isEmpty()) {
             item { EmptyDownloadQueueCard() }
         } else {
@@ -346,14 +344,25 @@ private fun DownloadSummaryCard(
 }
 
 @Composable
-private fun BackupFolderRequiredCard(onOpenSettings: () -> Unit) {
+private fun DownloadFolderSettingsCard(
+    folderReady: Boolean,
+    onOpenStorageSettings: () -> Unit,
+) {
     val colors = YamiboTheme.colors
     YamiboDownloadCard {
-        Text(i18n("尚未設定下載資料夾"), color = colors.textStrong, fontWeight = FontWeight.SemiBold)
+        Text(i18n("下載資料夾"), color = colors.textStrong, fontWeight = FontWeight.SemiBold)
         Spacer(Modifier.height(6.dp))
-        Text(i18n("下載內容會存放在本地資料備份指定的資料夾。"), color = colors.textDark.copy(alpha = 0.68f), fontSize = 13.sp)
+        Text(
+            text = if (folderReady) {
+                i18n("下載與備份資料夾由儲存空間設定統一管理。")
+            } else {
+                i18n("尚未設定下載資料夾，請先前往儲存空間選擇位置。")
+            },
+            color = colors.textDark.copy(alpha = 0.68f),
+            fontSize = 13.sp,
+        )
         Spacer(Modifier.height(12.dp))
-        SmallQueueButton(i18n("前往設定"), onOpenSettings)
+        SmallQueueButton(i18n("前往儲存空間"), onOpenStorageSettings)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -27,6 +28,7 @@ import me.thenano.yamibo.yamibo_app.i18n.localizedLabel
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
 import me.thenano.yamibo.yamibo_app.profile.download.IDownloadQueueScreen
 import me.thenano.yamibo.yamibo_app.profile.settings.access.IBackgroundAccessSetupScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.backup.rememberBackupFileActions
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.*
 import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsChipRow
 import me.thenano.yamibo.yamibo_app.profile.settings.components.ThemeSelectorContent
@@ -531,6 +533,57 @@ private fun SettingsActionRow(
 }
 
 @Composable
+private fun SharedStorageFolderCard(
+    folderLabel: String?,
+    onSelectFolder: () -> Unit,
+) {
+    val colors = YamiboTheme.colors
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        color = colors.creamSurface,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = i18n("下載與備份資料夾"),
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.textStrong,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = folderLabel ?: i18n("尚未選擇資料夾"),
+                fontSize = 13.sp,
+                color = colors.textDark.copy(alpha = 0.7f),
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = i18n("下載內容與本地備份共用此資料夾"),
+                    fontSize = 13.sp,
+                    color = colors.textDark.copy(alpha = 0.65f),
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(12.dp))
+                Surface(
+                    onClick = onSelectFolder,
+                    shape = RoundedCornerShape(8.dp),
+                    color = colors.brownLight.copy(alpha = 0.26f),
+                ) {
+                    Text(
+                        text = i18n(if (folderLabel == null) "選擇資料夾" else "變更資料夾"),
+                        fontSize = 13.sp,
+                        color = colors.brownDeep,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun RowScope.SettingsRowDescription(
     title: String,
     subtitle: String,
@@ -559,14 +612,17 @@ private fun StorageContent(feedbackController: me.thenano.yamibo.yamibo_app.feed
     val appSettingsRepo = LocalAppSettingsRepository.current
     val diskCacheFactory = LocalDiskCacheFactory.current
     val downloadRepository = LocalDownloadRepository.current
+    val backupRepository = LocalBackupRepository.current
     val coroutineScope = rememberCoroutineScope()
 
     val clearOnLaunch = appSettingsRepo.clearCacheOnAppLaunch.state()
+    var folderLabel by remember { mutableStateOf<String?>(null) }
     var cacheSizeText by remember { mutableStateOf(i18n("正在計算中...")) }
     var cacheBreakdown by remember { mutableStateOf(CacheStorageBreakdown(rootPath = "", usages = emptyList())) }
     var downloadSummary by remember { mutableStateOf(DownloadedContentSummary()) }
 
     suspend fun refreshCacheUsage() {
+        folderLabel = backupRepository.getSelectedFolderLabel()
         cacheBreakdown = diskCacheFactory.getCacheStorageBreakdown()
         downloadSummary = runCatching { downloadRepository.getDownloadedContentSummary() }
             .onFailure { Logger.w(TAG, "Failed to load downloaded content summary for storage settings", it) }
@@ -574,9 +630,32 @@ private fun StorageContent(feedbackController: me.thenano.yamibo.yamibo_app.feed
         cacheSizeText = formatStorageSize(cacheBreakdown.usages.sumOf { it.bytes })
     }
 
+    val folderActions = rememberBackupFileActions(
+        onFolderSelected = { uri ->
+            coroutineScope.launch {
+                backupRepository.setSelectedFolder(uri)
+                    .onSuccess {
+                        refreshCacheUsage()
+                        feedbackController.post(i18n("已選擇下載與備份資料夾"))
+                    }
+                    .onFailure { error ->
+                        Logger.e(TAG, "Failed to select shared storage folder", error)
+                        feedbackController.post(error.message ?: i18n("無法選擇資料夾"))
+                    }
+            }
+        },
+        onBackupPicked = {},
+    )
+
     LaunchedEffect(Unit) {
         refreshCacheUsage()
     }
+
+    SharedStorageFolderCard(
+        folderLabel = folderLabel,
+        onSelectFolder = folderActions.selectFolder,
+    )
+    Spacer(Modifier.height(24.dp))
 
     Row(
         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsScreen.kt
@@ -94,7 +94,7 @@ internal fun SettingsScreen() {
             SettingsItem(
                 icon = YamiboIcons.Storage,
                 title = i18n("儲存空間"),
-                subtitle = i18n("緩存空間與啟動時清理設定"),
+                subtitle = i18n("下載、備份資料夾與緩存清理設定"),
                 onClick = { navigator.navigate(ISettingsCategoryScreen("storage")) },
             )
             SettingsDivider()

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/backup/BackupSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/backup/BackupSettingsScreen.kt
@@ -60,19 +60,7 @@ internal fun BackupSettingsScreen() {
     }
 
     val fileActions = rememberBackupFileActions(
-        onFolderSelected = { uri ->
-            coroutineScope.launch {
-                repository.setSelectedFolder(uri)
-                    .onSuccess {
-                        refresh()
-                        feedbackController.post(i18n("已選擇備份資料夾"))
-                    }
-                    .onFailure { error ->
-                        Logger.e("BackupSettingsScreen", "Failed to select backup folder", error)
-                        feedbackController.post(error.message ?: i18n("無法選擇備份資料夾"))
-                    }
-            }
-        },
+        onFolderSelected = {},
         onBackupPicked = { uri -> pendingRestoreUri = uri },
     )
 
@@ -100,7 +88,9 @@ internal fun BackupSettingsScreen() {
                 folderLabel = folderLabel,
                 storageBytes = storageBytes,
                 backupCount = backupFiles.size,
-                onSelectFolder = fileActions.selectFolder,
+                onOpenStorageSettings = {
+                    navigator.navigate(me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen("storage"))
+                },
             )
             Text(
                 text = i18n("備份範圍包含收藏、設定、筆記、書籤、歷史進度與更新紀錄。"),
@@ -195,7 +185,7 @@ private fun BackupInfoCard(
     folderLabel: String?,
     storageBytes: Long,
     backupCount: Int,
-    onSelectFolder: () -> Unit,
+    onOpenStorageSettings: () -> Unit,
 ) {
     val colors = YamiboTheme.colors
     BackupCard {
@@ -216,7 +206,7 @@ private fun BackupInfoCard(
                 color = colors.textDark.copy(alpha = 0.65f),
                 modifier = Modifier.weight(1f),
             )
-            SmallBackupButton(text = i18n("選擇資料夾"), onClick = onSelectFolder)
+            SmallBackupButton(text = i18n("前往儲存空間"), onClick = onOpenStorageSettings)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/rss/RssSearchSubscriptionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/rss/RssSearchSubscriptionDetailScreen.kt
@@ -22,7 +22,7 @@ import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
 import me.thenano.yamibo.yamibo_app.favorite.*
 import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
-import me.thenano.yamibo.yamibo_app.profile.settings.backup.IBackupSettingsScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
 import me.thenano.yamibo.yamibo_app.repository.*
 import me.thenano.yamibo.yamibo_app.repository.download.RssMangaChapterDownloadKey
 import me.thenano.yamibo.yamibo_app.thread.detail.components.*
@@ -114,7 +114,7 @@ fun RssSearchSubscriptionDetailScreen(
     suspend fun ensureDownloadStorageReady(): Boolean {
         if (downloadRepository.isStorageReady()) return true
         feedbackController.post(i18n("尚未設定下載資料夾"))
-        navigator.navigate(IBackupSettingsScreen())
+        navigator.navigate(ISettingsCategoryScreen("storage"))
         return false
     }
 

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/tag/TagDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/tag/TagDetailScreen.kt
@@ -24,7 +24,7 @@ import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
 import me.thenano.yamibo.yamibo_app.favorite.*
 import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
-import me.thenano.yamibo.yamibo_app.profile.settings.backup.IBackupSettingsScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
 import me.thenano.yamibo.yamibo_app.repository.*
 import me.thenano.yamibo.yamibo_app.repository.download.TagMangaChapterDownloadKey
 import me.thenano.yamibo.yamibo_app.thread.detail.components.*
@@ -109,7 +109,7 @@ internal fun TagDetailScreen(
     suspend fun ensureDownloadStorageReady(): Boolean {
         if (downloadRepository.isStorageReady()) return true
         feedbackController.post(i18n("尚未設定下載資料夾"))
-        navigator.navigate(IBackupSettingsScreen())
+        navigator.navigate(ISettingsCategoryScreen("storage"))
         return false
     }
 

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ThreadReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ThreadReaderScreen.kt
@@ -57,7 +57,7 @@ import me.thenano.yamibo.yamibo_app.components.tracking.ReadingTimeTracker
 import me.thenano.yamibo.yamibo_app.favorite.*
 import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
-import me.thenano.yamibo.yamibo_app.profile.settings.backup.IBackupSettingsScreen
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
 import me.thenano.yamibo.yamibo_app.repository.BookMarkRepository
 import me.thenano.yamibo.yamibo_app.repository.ChapterStateRepository
 import me.thenano.yamibo.yamibo_app.repository.ContentCoverRepository
@@ -4819,7 +4819,7 @@ internal fun ThreadReaderScreen(
                                     error
                                 )
                                 feedbackController.post(error.message ?: i18n("下載失敗"))
-                                navigator.navigate(IBackupSettingsScreen())
+                                navigator.navigate(ISettingsCategoryScreen("storage"))
                             }
                     }
                 },
@@ -4836,7 +4836,7 @@ internal fun ThreadReaderScreen(
                                 )
                                 feedbackController.post(error.message ?: i18n("下載失敗"))
                                 if (!downloadRepository.isStorageReady()) {
-                                    navigator.navigate(IBackupSettingsScreen())
+                                    navigator.navigate(ISettingsCategoryScreen("storage"))
                                 }
                             }
                     }
@@ -4858,7 +4858,7 @@ internal fun ThreadReaderScreen(
                                 )
                                 feedbackController.post(error.message ?: i18n("下載失敗"))
                                 if (!downloadRepository.isStorageReady()) {
-                                    navigator.navigate(IBackupSettingsScreen())
+                                    navigator.navigate(ISettingsCategoryScreen("storage"))
                                 }
                             }
                     }

--- a/i18n/glossary.csv
+++ b/i18n/glossary.csv
@@ -854,3 +854,16 @@ RSS搜尋目錄(#{}),RSS search directory (#{}),RSS搜尋目錄(#{}),RSS搜尋�
 App 啟動時同步,Sync on app start,App 啟動時同步,App 启动时同步
 離開前台時同步,Sync when leaving foreground,離開前台時同步,离开前台时同步
 背景同步週期,Background sync interval,背景同步週期,后台同步周期
+下載資料夾,Download folder,下載資料夾,下载文件夹
+下載與備份資料夾,Download and backup folder,下載與備份資料夾,下载与备份文件夹
+下載內容與本地備份共用此資料夾；點擊可選擇或變更位置。,"Downloads and local backups share this folder; tap to select or change its location.",下載內容與本地備份共用此資料夾；點擊可選擇或變更位置。,下载内容与本地备份共用此文件夹；点击可选择或更改位置。
+下載內容與本地備份共用此資料夾,Downloads and local backups share this folder,下載內容與本地備份共用此資料夾,下载内容与本地备份共用此文件夹
+選擇資料夾,Select folder,選擇資料夾,选择文件夹
+變更資料夾,Change folder,變更資料夾,更改文件夹
+下載與備份資料夾由儲存空間設定統一管理。,The download and backup folder is managed in Storage settings.,下載與備份資料夾由儲存空間設定統一管理。,下载与备份文件夹由存储空间设置统一管理。
+前往儲存空間,Go to Storage,前往儲存空間,前往存储空间
+尚未設定下載資料夾，請先前往儲存空間選擇位置。,No download folder is set. Go to Storage to choose a location.,尚未設定下載資料夾，請先前往儲存空間選擇位置。,尚未设置下载文件夹，请先前往存储空间选择位置。
+尚未選擇資料夾,No folder selected,尚未選擇資料夾,尚未选择文件夹
+已選擇下載與備份資料夾,Download and backup folder selected,已選擇下載與備份資料夾,已选择下载与备份文件夹
+無法選擇資料夾,Unable to select folder,無法選擇資料夾,无法选择文件夹
+下載、備份資料夾與緩存清理設定,"Download and backup folder, and cache cleanup settings",下載、備份資料夾與緩存清理設定,下载、备份文件夹与缓存清理设置


### PR DESCRIPTION
## Problem and root cause
Download and backup folder selection was split across settings surfaces. Missing-folder flows also redirected users to backup settings, even though downloads and backups share the same persisted folder. This made the ownership of the storage location unclear and forced users to hunt across pages.

## Implementation and design decisions
- Make Settings > Storage the single owner of the shared folder picker and repository persistence.
- Present the picker as a rounded folder card with current state and a dedicated Select/Change folder button.
- Replace folder pickers on Download Management and Local Backup with navigation to Storage.
- Redirect missing-folder actions from favorites, thread reader, tag catalogs, and RSS catalogs to Storage.
- Add source-contract tests to keep picker ownership and redirects centralized.
- Document that repository branch names must not use the `codex/` prefix.

## User-visible behavior
Users configure one folder from Storage for both downloaded content and local backup files. Download and backup pages now link to that location. The folder card clearly shows whether a folder is selected and opens the Android system folder picker.

## Verification
- `./gradlew.bat :composeApp:compileDebugKotlinAndroid :composeApp:testDebugUnitTest --console=plain`
- Android Pixel 9 emulator: opened Storage, verified the rounded folder card and Select folder button, and confirmed it launches DocumentsUI.
- Android crash buffer was empty after the flow.
- `git diff --check`
- `git diff --name-only main...HEAD -- openspec/` returned no files.

## Risks, limits, and rollback
Risk is limited to navigation and shared-folder selection UI. Existing repository persistence remains unchanged. Rollback is the merge commit revert; previously selected folder data is not deleted.