### PR TITLE
feat: show download options after adding favorites

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadUiContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadUiContractTest.kt
@@ -1,0 +1,107 @@
+package me.thenano.yamibo.yamibo_app.favorite
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FavoritePostAddDownloadUiContractTest {
+    @Test
+    fun everyInteractiveFavoriteSourceUsesCreationOutcomeAndThePersistedGate() {
+        val sources = listOf(
+            "thread/reader/ThreadReaderScreen.kt",
+            "thread/detail/novel/NovelThreadDetailScreen.kt",
+            "thread/detail/tag/TagDetailScreen.kt",
+            "thread/detail/rss/RssSearchSubscriptionDetailScreen.kt",
+            "history/ReadHistoryPage.kt",
+            "forum/search/SearchScreen.kt",
+        ).map(::source)
+
+        sources.forEach { text ->
+            assertTrue(text.contains("favoriteAddDownloadPromptEnabled"))
+            assertTrue(text.contains("FavoriteCreationOutcome.Created"))
+        }
+        assertTrue(sources.take(5).all { it.contains("saveFavoriteWithOutcome") })
+        assertTrue(sources.last().contains("saveRssFavorite"))
+    }
+
+    @Test
+    fun automaticSheetsExposeSuppressionButManualSheetsDoNot() {
+        val suppression = source("thread/detail/components/DownloadPromptSuppression.kt")
+        val readerSheet = source("thread/reader/ReaderDownloadSheet.kt")
+        val catalogSheet = source("thread/detail/components/CatalogActions.kt")
+        val threadSource = source("thread/reader/ThreadReaderScreen.kt")
+        val tagSource = source("thread/detail/tag/TagDetailScreen.kt")
+        val rssSource = source("thread/detail/rss/RssSearchSubscriptionDetailScreen.kt")
+
+        assertTrue(suppression.contains("不要再詢問"))
+        assertTrue(suppression.contains("可在收藏設定重新開啟。"))
+        assertTrue(suppression.contains("checkedColor = colors.brownDeep"))
+        assertTrue(suppression.contains("checkmarkColor = colors.creamSurface"))
+        assertTrue(readerSheet.contains("doNotAskAgain: Boolean? = null"))
+        assertTrue(catalogSheet.contains("doNotAskAgain: Boolean? = null"))
+        listOf(threadSource, tagSource, rssSource).forEach { text ->
+            assertTrue(text.contains("downloadSheetOpenedAfterFavorite = false"))
+            assertTrue(text.contains("if (downloadSheetOpenedAfterFavorite)"))
+        }
+    }
+
+    @Test
+    fun existingManualDownloadLabelsAndOrderingRemainInSharedComponents() {
+        val reader = source("thread/reader/ReaderDownloadSheet.kt")
+        assertInOrder(
+            reader,
+            "下載目前頁",
+            "下載完整 Thread",
+            "下載除最後一頁的所有頁面",
+            "清除目前頁下載",
+            "清除整個 Thread 下載",
+        )
+
+        val tag = source("thread/detail/tag/TagDetailScreen.kt")
+        val rss = source("thread/detail/rss/RssSearchSubscriptionDetailScreen.kt")
+        listOf(tag, rss).forEach { text ->
+            assertInOrder(text, "下載目前分頁", "下載全部分頁", "清除目前分頁下載")
+        }
+    }
+
+    @Test
+    fun syncAndSaveMustFinishBeforeTheAutomaticSheetCanOpen() {
+        val thread = source("thread/reader/ThreadReaderScreen.kt")
+        val novel = source("thread/detail/novel/NovelThreadDetailScreen.kt")
+        val history = source("history/ReadHistoryPage.kt")
+
+        listOf(thread, novel).forEach { text ->
+            val sync = text.indexOf("completeSavedFavoriteSyncWithFeedback(")
+            val open = text.indexOf("if (pendingFavoriteDownloadAfterSync", startIndex = sync)
+            assertTrue(sync >= 0 && open > sync)
+        }
+        val historySync = history.indexOf("syncExistingFavoriteIfRequested(")
+        val historyOpen = history.indexOf("if (pendingFavoritePostAddDownloadTarget == target", startIndex = historySync)
+        assertTrue(historySync >= 0 && historyOpen > historySync)
+
+        val actions = source("favorite/FavoriteActions.kt")
+        val result = actions.indexOf("val result = withContext")
+        val feedback = actions.indexOf("feedbackController.post(message", startIndex = result)
+        val returned = actions.indexOf("return result", startIndex = feedback)
+        assertTrue(result >= 0 && feedback > result && returned > feedback)
+        assertFalse(actions.substring(returned).take(80).contains("showDownload"))
+    }
+
+    private fun assertInOrder(text: String, vararg labels: String) {
+        var cursor = -1
+        labels.forEach { label ->
+            val next = text.indexOf(label, cursor + 1)
+            assertTrue(next > cursor, "Expected '$label' after index $cursor")
+            cursor = next
+        }
+    }
+
+    private fun source(relative: String): String = repoRoot()
+        .resolve("composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/$relative")
+        .readText(Charsets.UTF_8)
+
+    private fun repoRoot(): File =
+        generateSequence(File(requireNotNull(System.getProperty("user.dir"))).absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoriteActions.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoriteActions.kt
@@ -93,19 +93,40 @@ internal fun FavoriteTargetPayload.taskIdentity(): String = when (this) {
     is FavoriteTargetPayload.RssSearch -> "rss:$subscriptionId"
 }
 
+internal enum class FavoriteCreationOutcome {
+    Created,
+    AlreadyExisted,
+}
+
+internal data class FavoriteAddResult(
+    val creationOutcome: FavoriteCreationOutcome,
+    val syncResult: FavoriteSyncActionResult?,
+)
+
+internal suspend fun FavoriteStoreRepository.saveFavoriteWithOutcome(
+    target: FavoriteTargetPayload,
+    categoryIds: List<Long> = emptyList(),
+    collectionIds: List<Long> = emptyList(),
+): FavoriteCreationOutcome {
+    val existed = findFavoriteItem(target) != null
+    saveFavorite(target, categoryIds, collectionIds)
+    return if (existed) FavoriteCreationOutcome.AlreadyExisted else FavoriteCreationOutcome.Created
+}
+
 internal suspend fun addFavoriteAndMaybeSync(
     favoriteRepository: FavoriteStoreRepository,
     favoriteSyncRepository: FavoriteSyncRepository,
     target: FavoriteTargetPayload,
     syncToRemote: Boolean,
-): FavoriteSyncActionResult? {
-    favoriteRepository.saveFavorite(target)
-    return syncExistingFavoriteIfRequested(
+): FavoriteAddResult {
+    val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
+    val syncResult = syncExistingFavoriteIfRequested(
         favoriteRepository = favoriteRepository,
         favoriteSyncRepository = favoriteSyncRepository,
         target = target,
         syncToRemote = syncToRemote,
     )
+    return FavoriteAddResult(creationOutcome, syncResult)
 }
 
 internal suspend fun syncExistingFavoriteIfRequested(
@@ -135,16 +156,17 @@ internal suspend fun completeFavoriteAddWithFeedback(
     target: FavoriteTargetPayload,
     syncToRemote: Boolean,
     feedbackController: me.thenano.yamibo.yamibo_app.feedback.AppFeedbackController,
-) {
+): FavoriteAddResult {
     val feedbackGroup = "favorite-add:${target.taskIdentity()}"
     if (syncToRemote) {
         feedbackController.post(i18n("正在同步到百合會..."), groupKey = feedbackGroup)
     }
-    val syncResult = withContext(Dispatchers.Default) {
+    val result = withContext(Dispatchers.Default) {
         addFavoriteAndMaybeSync(favoriteRepository, favoriteSyncRepository, target, syncToRemote)
     }
-    val message = favoriteSyncFeedbackMessage(syncResult, i18n("已加入收藏"))
+    val message = favoriteSyncFeedbackMessage(result.syncResult, i18n("已加入收藏"))
     feedbackController.post(message, groupKey = feedbackGroup)
+    return result
 }
 
 internal suspend fun completeSavedFavoriteSyncWithFeedback(

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoriteBatchDownload.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoriteBatchDownload.kt
@@ -7,6 +7,7 @@ import me.thenano.yamibo.yamibo_app.repository.FavoriteStoreRepository.FavoriteC
 import me.thenano.yamibo.yamibo_app.repository.FavoriteStoreRepository.FavoriteItem
 import me.thenano.yamibo.yamibo_app.repository.FavoriteStoreRepository.FavoriteTargetType
 import me.thenano.yamibo.yamibo_app.repository.RssSearchSubscriptionRepository
+import me.thenano.yamibo.yamibo_app.i18n.i18n
 
 internal enum class FavoriteBatchDownloadType {
     NovelThread,
@@ -36,6 +37,15 @@ internal data class FavoriteBatchDownloadResult(
     val failed: Int,
     val unsupported: Int,
 )
+
+internal fun favoriteBatchDownloadResultMessage(result: FavoriteBatchDownloadResult): String {
+    val skipped = result.skipped + result.unsupported
+    return when {
+        result.requested == 0 -> i18n("沒有可下載的收藏")
+        result.failed == 0 && skipped == 0 -> i18n("已加入下載佇列 {} 項", result.queued)
+        else -> i18n("已加入 {} 項，失敗 {} 項，跳過 {} 項", result.queued, result.failed, skipped)
+    }
+}
 
 internal class FavoriteBatchDownloadSubmissionGate {
     private var submitting = false

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePage.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePage.kt
@@ -219,15 +219,6 @@ fun FavoritePage() {
         )
     }
 
-    fun batchDownloadResultMessage(result: FavoriteBatchDownloadResult): String {
-        val skipped = result.skipped + result.unsupported
-        return when {
-            result.requested == 0 -> i18n("沒有可下載的收藏")
-            result.failed == 0 && skipped == 0 -> i18n("已加入下載佇列 {} 項", result.queued)
-            else -> i18n("已加入 {} 項，失敗 {} 項，跳過 {} 項", result.queued, result.failed, skipped)
-        }
-    }
-
     val favoriteShareFileActions = rememberFavoriteShareFileActions(
         onExported = { fileName -> showSnackbarMessage(i18n("已匯出 {}", fileName)) },
         onExportFailed = { message -> showSnackbarMessage(message) },
@@ -862,7 +853,7 @@ fun FavoritePage() {
                         val result = withContext(Dispatchers.Default) {
                             enqueueFavoriteBatchDownloads(downloadRepository, rssRepository, items, batchMode)
                         }
-                        showSnackbarMessage(batchDownloadResultMessage(result))
+                        showSnackbarMessage(favoriteBatchDownloadResultMessage(result))
                     } catch (error: CancellationException) {
                         throw error
                     } catch (error: Throwable) {

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadSheet.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadSheet.kt
@@ -1,0 +1,100 @@
+package me.thenano.yamibo.yamibo_app.favorite
+
+import androidx.compose.runtime.Composable
+import me.thenano.yamibo.yamibo_app.LocalAppFeedbackController
+import me.thenano.yamibo.yamibo_app.LocalAppTaskManager
+import me.thenano.yamibo.yamibo_app.LocalDownloadRepository
+import me.thenano.yamibo.yamibo_app.LocalFavoriteRepository
+import me.thenano.yamibo.yamibo_app.LocalRssSearchSubscriptionRepository
+import me.thenano.yamibo.yamibo_app.i18n.i18n
+import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
+import me.thenano.yamibo.yamibo_app.profile.settings.ISettingsCategoryScreen
+import me.thenano.yamibo.yamibo_app.thread.detail.components.CatalogDownloadAction
+import me.thenano.yamibo.yamibo_app.thread.detail.components.CatalogDownloadActionSheet
+import me.thenano.yamibo.yamibo_app.thread.reader.ReaderDownloadSheet
+import me.thenano.yamibo.yamibo_app.task.AppTaskKey
+
+internal enum class FavoritePostAddDownloadSurface {
+    ThreadReader,
+    TagCatalog,
+    RssCatalog,
+}
+
+internal fun FavoriteTargetPayload.postAddDownloadSurface(): FavoritePostAddDownloadSurface = when (this) {
+    is FavoriteTargetPayload.Thread -> FavoritePostAddDownloadSurface.ThreadReader
+    is FavoriteTargetPayload.TagManga -> FavoritePostAddDownloadSurface.TagCatalog
+    is FavoriteTargetPayload.RssSearch -> FavoritePostAddDownloadSurface.RssCatalog
+}
+
+/** Download choices shown only after a newly-created favorite. */
+@Composable
+internal fun FavoritePostAddDownloadSheet(
+    target: FavoriteTargetPayload,
+    doNotAskAgain: Boolean,
+    onDoNotAskAgainChange: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val downloadRepository = LocalDownloadRepository.current
+    val favoriteRepository = LocalFavoriteRepository.current
+    val rssRepository = LocalRssSearchSubscriptionRepository.current
+    val feedbackController = LocalAppFeedbackController.current
+    val appTaskManager = LocalAppTaskManager.current
+    val navigator = LocalNavigator.current
+
+    fun enqueue(mode: FavoriteBatchDownloadMode) {
+        onDismiss()
+        appTaskManager.launch(AppTaskKey("download:favorite-post-add:${target.taskIdentity()}:$mode")) {
+            if (!downloadRepository.isStorageReady()) {
+                feedbackController.post(i18n("尚未設定下載資料夾"))
+                navigator.navigate(ISettingsCategoryScreen("storage"))
+                return@launch
+            }
+            val item = favoriteRepository.findFavoriteItem(target)
+            if (item == null) {
+                feedbackController.post(i18n("找不到剛新增的收藏"))
+                return@launch
+            }
+            val result = enqueueFavoriteBatchDownloads(
+                downloadRepository = downloadRepository,
+                rssRepository = rssRepository,
+                items = listOf(item),
+                mode = mode,
+            )
+            feedbackController.post(favoriteBatchDownloadResultMessage(result))
+        }
+    }
+
+    when (target.postAddDownloadSurface()) {
+        FavoritePostAddDownloadSurface.ThreadReader -> ReaderDownloadSheet(
+            onDismiss = onDismiss,
+            showDownloadPage = false,
+            showDownloadThread = true,
+            showDownloadThreadExceptLastPage = true,
+            showClearPage = false,
+            showClearThread = false,
+            onDownloadPage = {},
+            onDownloadThread = { enqueue(FavoriteBatchDownloadMode.All) },
+            onDownloadThreadExceptLastPage = { enqueue(FavoriteBatchDownloadMode.ExceptLastPage) },
+            onClearPage = {},
+            onClearThread = {},
+            doNotAskAgain = doNotAskAgain,
+            onDoNotAskAgainChange = onDoNotAskAgainChange,
+        )
+
+        FavoritePostAddDownloadSurface.TagCatalog -> CatalogDownloadActionSheet(
+            title = i18n("標籤漫畫下載"),
+            actions = listOf(CatalogDownloadAction(i18n("下載全部分頁")) { enqueue(FavoriteBatchDownloadMode.All) }),
+            onDismiss = onDismiss,
+            doNotAskAgain = doNotAskAgain,
+            onDoNotAskAgainChange = onDoNotAskAgainChange,
+        )
+
+        FavoritePostAddDownloadSurface.RssCatalog -> CatalogDownloadActionSheet(
+            title = i18n("RSS 漫畫下載"),
+            actions = listOf(CatalogDownloadAction(i18n("下載全部分頁")) { enqueue(FavoriteBatchDownloadMode.All) }),
+            onDismiss = onDismiss,
+            doNotAskAgain = doNotAskAgain,
+            onDoNotAskAgainChange = onDoNotAskAgainChange,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/forum/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/forum/search/SearchScreen.kt
@@ -49,6 +49,7 @@ import me.thenano.yamibo.yamibo_app.thread.detail.rss.IRssSearchSubscriptionDeta
 import me.thenano.yamibo.yamibo_app.thread.reader.IThreadReaderScreen
 import me.thenano.yamibo.yamibo_app.userspace.IUserSpaceScreen
 import me.thenano.yamibo.yamibo_app.repository.FavoriteStoreRepository as FavoriteStoreRepositoryType
+import me.thenano.yamibo.yamibo_app.util.state
 
 private sealed interface SearchState {
     data object Idle : SearchState
@@ -68,6 +69,11 @@ private data class PendingRssFavorite(
     val searchPage: SearchPage,
 )
 
+private data class SavedRssFavorite(
+    val target: FavoriteTargetPayload.RssSearch,
+    val creationOutcome: FavoriteCreationOutcome,
+)
+
 @Composable
 fun SearchScreen(fid: ForumId?) {
     val colors = YamiboTheme.colors
@@ -78,6 +84,7 @@ fun SearchScreen(fid: ForumId?) {
     val navigator = LocalNavigator.current
     val scope = rememberCoroutineScope()
     val feedbackController = LocalAppFeedbackController.current
+    val appSettingsRepository = LocalAppSettingsRepository.current
     val focusRequester = remember { FocusRequester() }
     var searchFieldPlaced by remember { mutableStateOf(false) }
 
@@ -95,6 +102,8 @@ fun SearchScreen(fid: ForumId?) {
     }
     var favoriteDialogCategorySelection by remember { mutableStateOf<Set<Long>>(emptySet()) }
     var favoriteDialogCollectionSelection by remember { mutableStateOf<Set<Long>>(emptySet()) }
+    var favoritePostAddDownloadTarget by remember { mutableStateOf<FavoriteTargetPayload.RssSearch?>(null) }
+    val favoriteAddDownloadPromptEnabled = appSettingsRepository.favoriteAddDownloadPromptEnabled.state()
 
     fun navigateThread(thread: ThreadSummary) {
         val isNovelThread = fid?.let { YamiboForum.isNovelForum(it) }
@@ -165,7 +174,7 @@ fun SearchScreen(fid: ForumId?) {
         searchPage: SearchPage,
         categoryIds: Set<Long> = emptySet(),
         collectionIds: Set<Long> = emptySet(),
-    ): Long? {
+    ): SavedRssFavorite? {
         val existingSubscription = rssRepository.findBySearch(keyword, fid)
         val result = rssRepository.createFromSearch(
             title = keyword,
@@ -184,16 +193,19 @@ fun SearchScreen(fid: ForumId?) {
             title = keyword,
             coverUrl = null,
         )
-        try {
+        val creationOutcome = try {
             val existingItem = favoriteRepository.findFavoriteItem(target)
             if (existingItem == null) {
-                favoriteRepository.saveFavorite(
+                favoriteRepository.saveFavoriteWithOutcome(
                     target = target,
                     categoryIds = categoryIds.toList(),
                     collectionIds = collectionIds.toList(),
                 )
             } else if (categoryIds.isNotEmpty() || collectionIds.isNotEmpty()) {
                 favoriteRepository.setItemLocations(existingItem.id, categoryIds, collectionIds)
+                FavoriteCreationOutcome.AlreadyExisted
+            } else {
+                FavoriteCreationOutcome.AlreadyExisted
             }
         } catch (error: Throwable) {
             Logger.e("SearchScreen", "Failed to save RSS favorite keyword=$keyword", error)
@@ -207,7 +219,15 @@ fun SearchScreen(fid: ForumId?) {
         feedbackController.post(
             if (existingSubscription == null) i18n("已收藏為 RSS 訂閱") else i18n("已收藏此 RSS 訂閱")
         )
-        return result.value
+        return SavedRssFavorite(target, creationOutcome)
+    }
+
+    fun handleSavedRssFavorite(saved: SavedRssFavorite) {
+        if (saved.creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+            favoritePostAddDownloadTarget = saved.target
+        } else {
+            navigator.navigate(IRssSearchSubscriptionDetailScreen(saved.target.subscriptionId))
+        }
     }
 
     suspend fun openRssFavoritePicker(keyword: String, searchPage: SearchPage) {
@@ -320,10 +340,7 @@ fun SearchScreen(fid: ForumId?) {
                                     feedbackController.post(i18n("保存失敗"))
                             } else {
                                 scope.launch {
-                                    val subscriptionId = saveRssFavorite(keyword, currentState.page)
-                                    if (subscriptionId != null) {
-                                        navigator.navigate(IRssSearchSubscriptionDetailScreen(subscriptionId))
-                                    }
+                                    saveRssFavorite(keyword, currentState.page)?.let(::handleSavedRssFavorite)
                                 }
                             }
                         },
@@ -356,17 +373,29 @@ fun SearchScreen(fid: ForumId?) {
             },
             onConfirm = { selectedCategories, selectedCollections ->
                 scope.launch {
-                    val subscriptionId = saveRssFavorite(
+                    val saved = saveRssFavorite(
                         keyword = pending.keyword,
                         searchPage = pending.searchPage,
                         categoryIds = selectedCategories,
                         collectionIds = selectedCollections,
                     )
                     pendingRssFavorite = null
-                    if (subscriptionId != null) {
-                        navigator.navigate(IRssSearchSubscriptionDetailScreen(subscriptionId))
-                    }
+                    saved?.let(::handleSavedRssFavorite)
                 }
+            },
+        )
+    }
+
+    favoritePostAddDownloadTarget?.let { target ->
+        FavoritePostAddDownloadSheet(
+            target = target,
+            doNotAskAgain = !favoriteAddDownloadPromptEnabled,
+            onDoNotAskAgainChange = { checked ->
+                appSettingsRepository.favoriteAddDownloadPromptEnabled.setValue(!checked)
+            },
+            onDismiss = {
+                favoritePostAddDownloadTarget = null
+                navigator.navigate(IRssSearchSubscriptionDetailScreen(target.subscriptionId))
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/history/ReadHistoryPage.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/history/ReadHistoryPage.kt
@@ -36,6 +36,7 @@ import me.thenano.yamibo.yamibo_app.repository.ReadHistoryRepository
 import me.thenano.yamibo.yamibo_app.repository.ReadHistoryRepository.ThreadReadingHistory
 import me.thenano.yamibo.yamibo_app.thread.reader.IImageReaderScreen
 import me.thenano.yamibo.yamibo_app.thread.reader.IThreadReaderScreen
+import me.thenano.yamibo.yamibo_app.util.state
 import kotlin.math.ceil
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -85,7 +86,10 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
     var showFavoriteRemovalConfirm by remember { mutableStateOf(false) }
     var showFavoriteMultiPathDialog by remember { mutableStateOf(false) }
     var showFavoriteAddSyncConfirm by remember { mutableStateOf(false) }
+    var pendingFavoritePostAddDownloadTarget by remember { mutableStateOf<FavoriteTargetPayload?>(null) }
+    var favoritePostAddDownloadTarget by remember { mutableStateOf<FavoriteTargetPayload?>(null) }
     var showFavoriteRemoveSyncConfirm by remember { mutableStateOf(false) }
+    val favoriteAddDownloadPromptEnabled = appSettingsRepository.favoriteAddDownloadPromptEnabled.state()
 
     /** Re-tap History tab → open the topmost item's reader */
     LaunchedEffect(reTapToken) {
@@ -337,15 +341,19 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
     }
 
     suspend fun completeFavoriteAdd(target: FavoriteTargetPayload, syncToRemote: Boolean) {
-        val syncResult = withContext(Dispatchers.Default) {
+        val addResult = withContext(Dispatchers.Default) {
             addFavoriteAndMaybeSync(favoriteRepository, favoriteSyncRepository, target, syncToRemote)
         }
+        val syncResult = addResult.syncResult
         val message = when {
             syncResult == null -> i18n("已加入收藏，預設存入未分類")
             syncResult.success -> i18n("已加入收藏，{}", (syncResult.message?.let { i18n(it) }?.takeIf { it.isNotBlank() } ?: i18n("已同步到百合會。")))
             else -> i18n("已加入收藏，但同步失敗：{}", (syncResult.message?.let { i18n(it) }?.takeIf { it.isNotBlank() } ?: i18n("請稍後再試")))
         }
         feedbackController.post(message)
+        if (addResult.creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+            favoritePostAddDownloadTarget = target
+        }
     }
 
     suspend fun completeSavedFavoriteSync(target: FavoriteTargetPayload, syncToRemote: Boolean) {
@@ -362,6 +370,12 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
             else -> i18n("已加入本地收藏，但同步到百合會失敗：{}", (syncResult.message?.let { i18n(it) }?.takeIf { it.isNotBlank() } ?: i18n("請稍後再試")))
         }
         feedbackController.post(message, groupKey = feedbackGroup)
+        if (pendingFavoritePostAddDownloadTarget == target && favoriteAddDownloadPromptEnabled) {
+            favoritePostAddDownloadTarget = target
+        }
+        if (pendingFavoritePostAddDownloadTarget == target) {
+            pendingFavoritePostAddDownloadTarget = null
+        }
     }
 
     suspend fun completeFavoriteRemoval(target: FavoriteTargetPayload, removeRemote: Boolean) {
@@ -413,9 +427,12 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
         }
 
         if (target.supportsRemoteWebsiteSync() && appSettingsRepository.favoriteAddSyncPromptEnabled.getValue()) {
-            favoriteRepository.saveFavorite(target)
+            val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
             favoriteRefreshToken += 1
             pendingFavoriteRemovalTarget = target
+            pendingFavoritePostAddDownloadTarget = target.takeIf {
+                creationOutcome == FavoriteCreationOutcome.Created
+            }
             showFavoriteAddSyncConfirm = true
         } else {
             completeFavoriteAdd(
@@ -808,6 +825,17 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
         }
     }
 
+    favoritePostAddDownloadTarget?.let { target ->
+        FavoritePostAddDownloadSheet(
+            target = target,
+            doNotAskAgain = !favoriteAddDownloadPromptEnabled,
+            onDoNotAskAgainChange = { checked ->
+                appSettingsRepository.favoriteAddDownloadPromptEnabled.setValue(!checked)
+            },
+            onDismiss = { favoritePostAddDownloadTarget = null },
+        )
+    }
+
     if (favoriteDialogTarget != null) {
         FavoriteCollectionPickerDialog(
             categories = favoriteDialogCategories,
@@ -824,13 +852,16 @@ fun ReadHistoryPage(reTapToken: Int = 0) {
                     val target = favoriteDialogTarget ?: return@launch
                     val existing = favoriteRepository.findFavoriteItem(target)
                     if (existing == null) {
-                        favoriteRepository.saveFavorite(
+                        val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(
                             target,
                             categoryIds = selectedCategories.toList(),
                             collectionIds = selectedCollections.toList()
                         )
                         favoriteDialogTarget = null
                         favoriteRefreshToken += 1
+                        pendingFavoritePostAddDownloadTarget = target.takeIf {
+                            creationOutcome == FavoriteCreationOutcome.Created
+                        }
                         if (target.supportsRemoteWebsiteSync() && appSettingsRepository.favoriteAddSyncPromptEnabled.getValue()) {
                             pendingFavoriteRemovalTarget = target
                             showFavoriteAddSyncConfirm = true

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
@@ -227,6 +227,7 @@ private fun FavoriteSettingsContent(feedbackController: me.thenano.yamibo.yamibo
     val favoriteUpdateRunner = LocalFavoriteUpdateRunner.current
     val skipConfirm = appSettingsRepository.skipFavoriteRemovalConfirm.state()
     val addSyncPromptEnabled = appSettingsRepository.favoriteAddSyncPromptEnabled.state()
+    val addDownloadPromptEnabled = appSettingsRepository.favoriteAddDownloadPromptEnabled.state()
     val addSyncDefault = appSettingsRepository.favoriteAddSyncDefault.state()
     val removeSyncPromptEnabled = appSettingsRepository.favoriteRemoveSyncPromptEnabled.state()
     val removeSyncDefault = appSettingsRepository.favoriteRemoveSyncDefault.state()
@@ -334,6 +335,15 @@ private fun FavoriteSettingsContent(feedbackController: me.thenano.yamibo.yamibo
     Spacer(Modifier.height(24.dp))
 
     SectionLabel(i18n("收藏同步偏好"))
+
+    SettingsToggleRow(
+        title = i18n("收藏後顯示下載選項"),
+        subtitle = i18n("開啟後，新增收藏完成時會顯示適用的下載選項。"),
+        checked = addDownloadPromptEnabled,
+        onCheckedChange = { appSettingsRepository.favoriteAddDownloadPromptEnabled.setValue(it) },
+    )
+
+    Spacer(Modifier.height(18.dp))
     SettingsActionRow(
         title = i18n("通知與背景同步設定"),
         subtitle = i18n("檢查通知權限、電池最佳化與背景同步所需的系統設定。"),

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/components/CatalogActions.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/components/CatalogActions.kt
@@ -53,6 +53,8 @@ internal fun CatalogDownloadActionSheet(
     title: String,
     actions: List<CatalogDownloadAction>,
     onDismiss: () -> Unit,
+    doNotAskAgain: Boolean? = null,
+    onDoNotAskAgainChange: ((Boolean) -> Unit)? = null,
 ) {
     val colors = YamiboTheme.colors
     ModalBottomSheet(
@@ -69,6 +71,9 @@ internal fun CatalogDownloadActionSheet(
             Text(title, color = colors.textStrong, style = MaterialTheme.typography.titleMedium)
             actions.forEach { action ->
                 CatalogActionRow(action.label, action.onClick)
+            }
+            if (doNotAskAgain != null && onDoNotAskAgainChange != null) {
+                DownloadPromptSuppressionRow(doNotAskAgain, onDoNotAskAgainChange)
             }
             Spacer(Modifier.height(4.dp))
         }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/components/DownloadPromptSuppression.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/components/DownloadPromptSuppression.kt
@@ -1,0 +1,59 @@
+package me.thenano.yamibo.yamibo_app.thread.detail.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
+import me.thenano.yamibo.yamibo_app.i18n.i18n
+
+@Composable
+internal fun DownloadPromptSuppressionRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val colors = YamiboTheme.colors
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = CheckboxDefaults.colors(
+                checkedColor = colors.brownDeep,
+                uncheckedColor = colors.textDark.copy(alpha = 0.45f),
+                checkmarkColor = colors.creamSurface,
+            ),
+        )
+        Spacer(Modifier.width(8.dp))
+        Column(Modifier.fillMaxWidth()) {
+            Text(
+                text = i18n("不要再詢問"),
+                color = colors.textStrong,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = i18n("可在收藏設定重新開啟。"),
+                color = colors.textDark.copy(alpha = 0.65f),
+                fontSize = 12.sp,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/novel/NovelThreadDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/novel/NovelThreadDetailScreen.kt
@@ -32,6 +32,7 @@ import me.thenano.yamibo.yamibo_app.thread.detail.components.DetailNoteEditorDia
 import me.thenano.yamibo.yamibo_app.thread.detail.novel.components.*
 import me.thenano.yamibo.yamibo_app.thread.reader.IThreadReaderScreen
 import me.thenano.yamibo.yamibo_app.util.shareText
+import me.thenano.yamibo.yamibo_app.util.state
 import me.thenano.yamibo.yamibo_app.util.time.epochMillisOrNull
 
 /** Thread detail state */
@@ -84,6 +85,8 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
     var showFavoriteRemovalConfirm by remember { mutableStateOf(false) }
     var showFavoriteMultiPathDialog by remember { mutableStateOf(false) }
     var showFavoriteAddSyncConfirm by remember { mutableStateOf(false) }
+    var pendingFavoriteDownloadAfterSync by remember { mutableStateOf(false) }
+    var favoritePostAddDownloadTarget by remember { mutableStateOf<FavoriteTargetPayload?>(null) }
     var showFavoriteRemoveSyncConfirm by remember { mutableStateOf(false) }
     var detailNote by remember { mutableStateOf<DetailNoteRepository.DetailNote?>(null) }
     var showNoteDialog by remember { mutableStateOf(false) }
@@ -95,6 +98,7 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
         ContentCoverRepository.Key(ContentCoverRepository.TargetType.ThreadNovel, tid.value.toLong())
     }
     val canonicalCover by contentCoverRepository.observeCover(coverKey).collectAsState(null)
+    val favoriteAddDownloadPromptEnabled = appSettingsRepo.favoriteAddDownloadPromptEnabled.state()
 
     suspend fun reloadReadingHistory() {
         readHistory = try {
@@ -184,13 +188,17 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
     }
 
     suspend fun completeFavoriteAdd(syncToRemote: Boolean) {
-        completeFavoriteAddWithFeedback(
+        val target = favoriteTarget()
+        val result = completeFavoriteAddWithFeedback(
             favoriteRepository = favoriteRepository,
             favoriteSyncRepository = favoriteSyncRepository,
-            target = favoriteTarget(),
+            target = target,
             syncToRemote = syncToRemote,
             feedbackController = feedbackController,
         )
+        if (result.creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+            favoritePostAddDownloadTarget = target
+        }
     }
 
     suspend fun completeSavedFavoriteSync(syncToRemote: Boolean) {
@@ -201,6 +209,10 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
             syncToRemote = syncToRemote,
             feedbackController = feedbackController,
         )
+        if (pendingFavoriteDownloadAfterSync && favoriteAddDownloadPromptEnabled) {
+            favoritePostAddDownloadTarget = favoriteTarget()
+        }
+        pendingFavoriteDownloadAfterSync = false
     }
 
     suspend fun completeFavoriteRemoval(removeRemote: Boolean) {
@@ -252,8 +264,9 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
         }
 
         if (target.supportsRemoteWebsiteSync() && appSettingsRepo.favoriteAddSyncPromptEnabled.getValue()) {
-            favoriteRepository.saveFavorite(target)
+            val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
             favoriteRefreshToken += 1
+            pendingFavoriteDownloadAfterSync = creationOutcome == FavoriteCreationOutcome.Created
             showFavoriteAddSyncConfirm = true
         } else {
             completeFavoriteAdd(
@@ -483,6 +496,17 @@ internal fun NovelThreadDetailScreen(tid: ThreadId, title: String, authorId: Use
         }
     }
 
+favoritePostAddDownloadTarget?.let { target ->
+    FavoritePostAddDownloadSheet(
+        target = target,
+        doNotAskAgain = !favoriteAddDownloadPromptEnabled,
+        onDoNotAskAgainChange = { checked ->
+            appSettingsRepo.favoriteAddDownloadPromptEnabled.setValue(!checked)
+        },
+        onDismiss = { favoritePostAddDownloadTarget = null },
+    )
+}
+
 if (showFavoriteDialog) {
     val target = FavoriteTargetPayload.Thread(
         tid = tid,
@@ -510,13 +534,14 @@ if (showFavoriteDialog) {
             scope.launch {
                 val existing = favoriteRepository.findFavoriteItem(target)
                 if (existing == null) {
-                    favoriteRepository.saveFavorite(
+                    val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(
                         target,
                         categoryIds = selectedCategories.toList(),
                         collectionIds = selectedCollections.toList()
                     )
                     showFavoriteDialog = false
                     favoriteRefreshToken += 1
+                    pendingFavoriteDownloadAfterSync = creationOutcome == FavoriteCreationOutcome.Created
                     if (target.supportsRemoteWebsiteSync() && appSettingsRepo.favoriteAddSyncPromptEnabled.getValue()) {
                         showFavoriteAddSyncConfirm = true
                     } else {

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/rss/RssSearchSubscriptionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/rss/RssSearchSubscriptionDetailScreen.kt
@@ -89,8 +89,10 @@ fun RssSearchSubscriptionDetailScreen(
     var showFavoriteRemovalConfirm by remember { mutableStateOf(false) }
     var showFavoriteMultiPathDialog by remember { mutableStateOf(false) }
     var showDownloadSheet by remember { mutableStateOf(false) }
+    var downloadSheetOpenedAfterFavorite by remember { mutableStateOf(false) }
 
     val isMangaMode = appSettingsRepo.isMangaMode.state()
+    val favoriteAddDownloadPromptEnabled = appSettingsRepo.favoriteAddDownloadPromptEnabled.state()
     val longStripModeEnabled by imageReaderModeOverrideRepository
         .observeRssLongStrip(subscriptionId)
         .collectAsState(false)
@@ -402,9 +404,13 @@ fun RssSearchSubscriptionDetailScreen(
                                 val target = favoriteTarget()
                                 val selection = favoriteRepository.getFavoriteLocationSelection(target)
                                 if (selection.item == null) {
-                                    favoriteRepository.saveFavorite(target)
+                                    val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
                                     favoriteRefreshToken += 1
                                     feedbackController.post(i18n("已加入收藏"))
+                                    if (creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+                                        downloadSheetOpenedAfterFavorite = true
+                                        showDownloadSheet = true
+                                    }
                                 } else {
                                     pendingFavoriteRemovalSelection = selection
                                     if (appSettingsRepo.skipFavoriteRemovalConfirm.getValue()) {
@@ -432,7 +438,10 @@ fun RssSearchSubscriptionDetailScreen(
                             shareText(platformContext, "RSS: ${currentTitle()}", currentTitle())
                         },
                         showDownloadAction = isMangaMode,
-                        onDownload = { showDownloadSheet = true },
+                        onDownload = {
+                            downloadSheetOpenedAfterFavorite = false
+                            showDownloadSheet = true
+                        },
                         noteContent = detailNote?.content.orEmpty(),
                         onNoteClick = { showNoteDialog = true },
                         onPageChange = { pageIndex ->
@@ -593,10 +602,14 @@ fun RssSearchSubscriptionDetailScreen(
         val currentPageHasDownloads = currentThreads.any { rssDownloadEntries.containsKey(it.tid.value.toLong()) }
         CatalogDownloadActionSheet(
             title = i18n("RSS 漫畫下載"),
-            onDismiss = { showDownloadSheet = false },
+            onDismiss = {
+                showDownloadSheet = false
+                downloadSheetOpenedAfterFavorite = false
+            },
             actions = buildList {
                 add(CatalogDownloadAction(i18n("下載目前分頁")) {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("current-page:$currentPage") {
                         if (!ensureDownloadStorageReady()) return@launchDownloadTask
                         downloadRepository.enqueueRssMangaCurrentPage(subscriptionId, currentTitle(), currentQuery(), currentThreads, currentPage)
@@ -608,6 +621,7 @@ fun RssSearchSubscriptionDetailScreen(
                 })
                 add(CatalogDownloadAction(i18n("下載全部分頁")) {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("all-pages") {
                         if (!ensureDownloadStorageReady()) return@launchDownloadTask
                         downloadRepository.enqueueRssMangaAllPages(subscriptionId, currentTitle(), currentQuery())
@@ -620,6 +634,7 @@ fun RssSearchSubscriptionDetailScreen(
                 if (currentPageHasDownloads) {
                     add(CatalogDownloadAction(i18n("清除目前分頁下載")) {
                         showDownloadSheet = false
+                        downloadSheetOpenedAfterFavorite = false
                         launchDownloadTask("clear-page:$currentPage") {
                             currentThreads.forEach { downloadRepository.clearRssMangaChapter(rssMangaKey(it)) }
                             feedbackController.post(i18n("已清除目前分頁下載"))
@@ -629,12 +644,23 @@ fun RssSearchSubscriptionDetailScreen(
                 if (rssDownloadEntries.isNotEmpty()) {
                     add(CatalogDownloadAction(i18n("清除整個 RSS 下載")) {
                         showDownloadSheet = false
+                        downloadSheetOpenedAfterFavorite = false
                         launchDownloadTask("clear-all") {
                             downloadRepository.clearRssManga(subscriptionId)
                             feedbackController.post(i18n("已清除整個 RSS 下載"))
                         }
                     })
                 }
+            },
+            doNotAskAgain = if (downloadSheetOpenedAfterFavorite) {
+                !favoriteAddDownloadPromptEnabled
+            } else {
+                null
+            },
+            onDoNotAskAgainChange = if (downloadSheetOpenedAfterFavorite) {
+                { checked -> appSettingsRepo.favoriteAddDownloadPromptEnabled.setValue(!checked) }
+            } else {
+                null
             },
         )
     }
@@ -655,7 +681,15 @@ fun RssSearchSubscriptionDetailScreen(
                 scope.launch {
                     val existing = favoriteRepository.findFavoriteItem(target)
                     if (existing == null) {
-                        favoriteRepository.saveFavorite(target, selectedCategories.toList(), selectedCollections.toList())
+                        val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(
+                            target,
+                            selectedCategories.toList(),
+                            selectedCollections.toList(),
+                        )
+                        if (creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+                            downloadSheetOpenedAfterFavorite = true
+                            showDownloadSheet = true
+                        }
                     } else {
                         favoriteRepository.setItemLocations(existing.id, selectedCategories, selectedCollections)
                     }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/tag/TagDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/detail/tag/TagDetailScreen.kt
@@ -91,10 +91,12 @@ internal fun TagDetailScreen(
     var threadChapterStates by remember { mutableStateOf<Map<Long, ChapterStateRepository.Entry>>(emptyMap()) }
     var actionThread by remember { mutableStateOf<ThreadSummary?>(null) }
     var showDownloadSheet by remember { mutableStateOf(false) }
+    var downloadSheetOpenedAfterFavorite by remember { mutableStateOf(false) }
 
     val appSettingsRepo = LocalAppSettingsRepository.current
     val imageReaderModeOverrideRepository = LocalImageReaderModeOverrideRepository.current
     val isMangaMode = appSettingsRepo.isMangaMode.state()
+    val favoriteAddDownloadPromptEnabled = appSettingsRepo.favoriteAddDownloadPromptEnabled.state()
     val longStripModeEnabled by imageReaderModeOverrideRepository.observeTagLongStrip(tagId).collectAsState(false)
     val stackSize = navigator.stack.size
 
@@ -260,9 +262,13 @@ internal fun TagDetailScreen(
             return
         }
 
-        favoriteRepository.saveFavorite(target)
+        val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
         favoriteRefreshToken += 1
         feedbackController.post(i18n("已加入收藏"))
+        if (creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+            downloadSheetOpenedAfterFavorite = true
+            showDownloadSheet = true
+        }
     }
 
     LaunchedEffect(tagId, currentTagName, favoriteRefreshToken, canonicalCover?.resolvedUrl) {
@@ -515,7 +521,10 @@ internal fun TagDetailScreen(
                                 shareText(platformContext, url, currentTagName)
                             },
                             showDownloadAction = isMangaMode,
-                            onDownload = { showDownloadSheet = true },
+                            onDownload = {
+                                downloadSheetOpenedAfterFavorite = false
+                                showDownloadSheet = true
+                            },
                             noteContent = detailNote?.content.orEmpty(),
                             onNoteClick = { showNoteDialog = true },
                             onPageChange = { page ->
@@ -565,10 +574,14 @@ internal fun TagDetailScreen(
         val currentPageHasDownloads = currentThreads.any { tagMangaDownloadEntries.containsKey(it.tid.value.toLong()) }
         CatalogDownloadActionSheet(
             title = i18n("標籤漫畫下載"),
-            onDismiss = { showDownloadSheet = false },
+            onDismiss = {
+                showDownloadSheet = false
+                downloadSheetOpenedAfterFavorite = false
+            },
             actions = buildList {
                 add(CatalogDownloadAction(i18n("下載目前分頁")) {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("current-page:$currentPage") {
                         if (!ensureDownloadStorageReady()) return@launchDownloadTask
                         downloadRepository.enqueueTagMangaCurrentPage(
@@ -584,6 +597,7 @@ internal fun TagDetailScreen(
                 })
                 add(CatalogDownloadAction(i18n("下載全部分頁")) {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("all-pages") {
                         if (!ensureDownloadStorageReady()) return@launchDownloadTask
                         downloadRepository.enqueueTagMangaAllPages(tagId, currentTagName)
@@ -596,6 +610,7 @@ internal fun TagDetailScreen(
                 if (currentPageHasDownloads) {
                     add(CatalogDownloadAction(i18n("清除目前分頁下載")) {
                         showDownloadSheet = false
+                        downloadSheetOpenedAfterFavorite = false
                         launchDownloadTask("clear-page:$currentPage") {
                             currentThreads.forEach { downloadRepository.clearTagMangaChapter(tagMangaKey(it)) }
                             feedbackController.post(i18n("已清除目前分頁下載"))
@@ -605,12 +620,23 @@ internal fun TagDetailScreen(
                 if (tagMangaDownloadEntries.isNotEmpty()) {
                     add(CatalogDownloadAction(i18n("清除整個標籤下載")) {
                         showDownloadSheet = false
+                        downloadSheetOpenedAfterFavorite = false
                         launchDownloadTask("clear-all") {
                             downloadRepository.clearTagManga(tagId)
                             feedbackController.post(i18n("已清除整個標籤下載"))
                         }
                     })
                 }
+            },
+            doNotAskAgain = if (downloadSheetOpenedAfterFavorite) {
+                !favoriteAddDownloadPromptEnabled
+            } else {
+                null
+            },
+            onDoNotAskAgainChange = if (downloadSheetOpenedAfterFavorite) {
+                { checked -> appSettingsRepo.favoriteAddDownloadPromptEnabled.setValue(!checked) }
+            } else {
+                null
             },
         )
     }
@@ -635,7 +661,7 @@ internal fun TagDetailScreen(
                 scope.launch {
                     val existing = favoriteRepository.findFavoriteItem(target)
                     if (existing == null) {
-                        favoriteRepository.saveFavorite(
+                        val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(
                             target,
                             categoryIds = selectedCategories.toList(),
                             collectionIds = selectedCollections.toList()
@@ -643,6 +669,10 @@ internal fun TagDetailScreen(
                         showFavoriteDialog = false
                         favoriteRefreshToken += 1
                         feedbackController.post(i18n("已加入收藏"))
+                        if (creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+                            downloadSheetOpenedAfterFavorite = true
+                            showDownloadSheet = true
+                        }
                     } else if (selectedCategories.isEmpty() && selectedCollections.isEmpty()) {
                         showFavoriteDialog = false
                         pendingFavoriteRemovalSelection = favoriteRepository.getFavoriteLocationSelection(target)

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ReaderDownloadSheet.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ReaderDownloadSheet.kt
@@ -1,0 +1,141 @@
+package me.thenano.yamibo.yamibo_app.thread.reader
+
+import YamiboIcons
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
+import me.thenano.yamibo.yamibo_app.i18n.i18n
+import me.thenano.yamibo.yamibo_app.thread.detail.components.DownloadPromptSuppressionRow
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun ReaderDownloadSheet(
+    onDismiss: () -> Unit,
+    showDownloadPage: Boolean,
+    showDownloadThread: Boolean,
+    showDownloadThreadExceptLastPage: Boolean,
+    showClearPage: Boolean,
+    showClearThread: Boolean,
+    onDownloadPage: () -> Unit,
+    onDownloadThread: () -> Unit,
+    onDownloadThreadExceptLastPage: () -> Unit,
+    onClearPage: () -> Unit,
+    onClearThread: () -> Unit,
+    doNotAskAgain: Boolean? = null,
+    onDoNotAskAgainChange: ((Boolean) -> Unit)? = null,
+) {
+    val colors = YamiboTheme.colors
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = colors.creamSurface,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(i18n("下載"), color = colors.textStrong, fontSize = 22.sp)
+            Text(
+                text = i18n("下載會保存整頁帖子與原始圖片。"),
+                color = colors.textDark.copy(alpha = 0.68f),
+                fontSize = 13.sp,
+            )
+            if (showDownloadPage) {
+                DownloadSheetAction(i18n("下載目前頁"), i18n("保存此頁所有帖子與圖片"), false, onDownloadPage)
+            }
+            if (showDownloadThread) {
+                DownloadSheetAction(i18n("下載完整 Thread"), i18n("將全部頁面加入背景佇列"), false, onDownloadThread)
+            }
+            if (showDownloadThreadExceptLastPage) {
+                DownloadSheetAction(
+                    i18n("下載除最後一頁的所有頁面"),
+                    i18n("保留可能持續更新的最後一頁在線閱讀"),
+                    false,
+                    onDownloadThreadExceptLastPage,
+                )
+            }
+            if (showClearPage) {
+                DownloadSheetAction(i18n("清除目前頁下載"), i18n("只刪除此頁離線內容"), true, onClearPage)
+            }
+            if (showClearThread) {
+                DownloadSheetAction(
+                    i18n("清除整個 Thread 下載"),
+                    i18n("取消佇列並刪除所有已下載頁"),
+                    true,
+                    onClearThread,
+                )
+            }
+            if (doNotAskAgain != null && onDoNotAskAgainChange != null) {
+                DownloadPromptSuppressionRow(doNotAskAgain, onDoNotAskAgainChange)
+            }
+            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                Text(i18n("關閉"), color = colors.brownPrimary)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadSheetAction(
+    title: String,
+    subtitle: String,
+    destructive: Boolean,
+    onClick: () -> Unit,
+) {
+    val colors = YamiboTheme.colors
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.creamBackground),
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = YamiboIcons.Download,
+                contentDescription = null,
+                tint = if (destructive) colors.redAccent else colors.orangeAccent,
+                modifier = Modifier.size(22.dp),
+            )
+            Column(Modifier.padding(start = 12.dp)) {
+                Text(
+                    text = title,
+                    color = if (destructive) colors.redAccent else colors.textStrong,
+                    fontSize = 15.sp,
+                )
+                Text(
+                    text = subtitle,
+                    color = colors.textDark.copy(alpha = 0.65f),
+                    fontSize = 12.sp,
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ThreadReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/ThreadReaderScreen.kt
@@ -623,6 +623,7 @@ internal fun ThreadReaderScreen(
     val isNovelThread = threadType == ReadHistoryRepository.ThreadEntryType.Novel
     val keepSystemBarsBackground = novelSettingsRepository.keepSystemBarsBackground.state()
     val readerFontSize = novelSettingsRepository.fontSize.state()
+    val favoriteAddDownloadPromptEnabled = appSettingsRepository.favoriteAddDownloadPromptEnabled.state()
     val readerLineSpacing = novelSettingsRepository.lineSpacing.state()
     val readerFontId = novelSettingsRepository.readerFontId.state()
     val readerContentWidthFraction = novelSettingsRepository.contentWidthFraction.state()
@@ -689,6 +690,7 @@ internal fun ThreadReaderScreen(
     var showMenu by remember { mutableStateOf(false) }
     var showSettingsPanel by remember { mutableStateOf(false) }
     var showDownloadSheet by remember { mutableStateOf(false) }
+    var downloadSheetOpenedAfterFavorite by remember { mutableStateOf(false) }
     var downloadSheetPage by remember(tid, authorId) { mutableIntStateOf(initialPage) }
     var showRefreshDownloadedDialog by remember { mutableStateOf(false) }
     var showDownloadedLastPageWarning by remember { mutableStateOf(false) }
@@ -784,6 +786,7 @@ internal fun ThreadReaderScreen(
     var showFavoriteRemovalConfirm by remember { mutableStateOf(false) }
     var showFavoriteMultiPathDialog by remember { mutableStateOf(false) }
     var showFavoriteAddSyncConfirm by remember { mutableStateOf(false) }
+    var pendingFavoriteDownloadAfterSync by remember { mutableStateOf(false) }
     var showFavoriteRemoveSyncConfirm by remember { mutableStateOf(false) }
     var postBookMarkEntries by remember { mutableStateOf<Map<Long, BookMarkRepository.Entry>>(emptyMap()) }
     var catalogActionPost by remember { mutableStateOf<Post?>(null) }
@@ -861,13 +864,17 @@ internal fun ThreadReaderScreen(
     }
 
     suspend fun completeFavoriteAdd(syncToRemote: Boolean) {
-        completeFavoriteAddWithFeedback(
+        val result = completeFavoriteAddWithFeedback(
             favoriteRepository = favoriteRepository,
             favoriteSyncRepository = favoriteSyncRepository,
             target = favoriteTarget(),
             syncToRemote = syncToRemote,
             feedbackController = feedbackController,
         )
+        if (result.creationOutcome == FavoriteCreationOutcome.Created && favoriteAddDownloadPromptEnabled) {
+            downloadSheetOpenedAfterFavorite = true
+            showDownloadSheet = true
+        }
     }
 
     suspend fun completeSavedFavoriteSync(syncToRemote: Boolean) {
@@ -878,6 +885,11 @@ internal fun ThreadReaderScreen(
             syncToRemote = syncToRemote,
             feedbackController = feedbackController,
         )
+        if (pendingFavoriteDownloadAfterSync && favoriteAddDownloadPromptEnabled) {
+            downloadSheetOpenedAfterFavorite = true
+            showDownloadSheet = true
+        }
+        pendingFavoriteDownloadAfterSync = false
     }
 
     suspend fun completeFavoriteRemoval(removeRemote: Boolean) {
@@ -930,8 +942,9 @@ internal fun ThreadReaderScreen(
         }
 
         if (target.supportsRemoteWebsiteSync() && appSettingsRepository.favoriteAddSyncPromptEnabled.getValue()) {
-            favoriteRepository.saveFavorite(target)
+            val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(target)
             favoriteRefreshToken += 1
+            pendingFavoriteDownloadAfterSync = creationOutcome == FavoriteCreationOutcome.Created
             showFavoriteAddSyncConfirm = true
         } else {
             completeFavoriteAdd(
@@ -3408,6 +3421,7 @@ internal fun ThreadReaderScreen(
                                 downloadSheetPage = currentVisiblePageForAction()
                                 drawerState.close()
                                 withFrameNanos { }
+                                downloadSheetOpenedAfterFavorite = false
                                 showDownloadSheet = true
                             }
                         },
@@ -4798,7 +4812,10 @@ internal fun ThreadReaderScreen(
                 .filter { it.second.status in completedOrActiveStatuses }
                 .mapTo(mutableSetOf()) { it.first.page }
             ReaderDownloadSheet(
-                onDismiss = { showDownloadSheet = false },
+                onDismiss = {
+                    showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
+                },
                 showDownloadPage = pageStatus == DownloadStatus.NotDownloaded ||
                     pageStatus == DownloadStatus.Failed,
                 showDownloadThread = (1..totalPages).any { it !in completedOrActivePages },
@@ -4809,6 +4826,7 @@ internal fun ThreadReaderScreen(
                 onDownloadPage = {
                     val page = downloadSheetPage
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("page:$page") {
                         downloadRepository.enqueuePage(tid, threadInfo?.title ?: title, authorId, page)
                             .onSuccess { feedbackController.post(i18n("已加入下載佇列")) }
@@ -4825,6 +4843,7 @@ internal fun ThreadReaderScreen(
                 },
                 onDownloadThread = {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("all") {
                         downloadRepository.enqueueThread(tid, threadInfo?.title ?: title, authorId)
                             .onSuccess { feedbackController.post(i18n("已加入完整 Thread 下載")) }
@@ -4843,6 +4862,7 @@ internal fun ThreadReaderScreen(
                 },
                 onDownloadThreadExceptLastPage = {
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("except-last") {
                         downloadRepository.enqueueThreadExceptLastPage(
                             tid,
@@ -4866,6 +4886,7 @@ internal fun ThreadReaderScreen(
                 onClearPage = {
                     val page = downloadSheetPage
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("clear-page:$page") {
                         downloadRepository.clearPage(ThreadPageDownloadKey(tid.value, page, authorId?.value))
                         feedbackController.post(i18n("已清除目前頁下載"))
@@ -4874,10 +4895,21 @@ internal fun ThreadReaderScreen(
                 onClearThread = {
                     val page = currentVisiblePageForAction()
                     showDownloadSheet = false
+                    downloadSheetOpenedAfterFavorite = false
                     launchDownloadTask("clear-thread") {
                         downloadRepository.clearThread(ThreadPageDownloadKey(tid.value, page, authorId?.value))
                         feedbackController.post(i18n("已清除整個 Thread 下載"))
                     }
+                },
+                doNotAskAgain = if (downloadSheetOpenedAfterFavorite) {
+                    !favoriteAddDownloadPromptEnabled
+                } else {
+                    null
+                },
+                onDoNotAskAgainChange = if (downloadSheetOpenedAfterFavorite) {
+                    { checked -> appSettingsRepository.favoriteAddDownloadPromptEnabled.setValue(!checked) }
+                } else {
+                    null
                 },
             )
         }
@@ -4999,13 +5031,14 @@ internal fun ThreadReaderScreen(
                 scope.launch {
                     val existing = favoriteRepository.findFavoriteItem(target)
                     if (existing == null) {
-                        favoriteRepository.saveFavorite(
+                        val creationOutcome = favoriteRepository.saveFavoriteWithOutcome(
                             target,
                             categoryIds = selectedCategories.toList(),
                             collectionIds = selectedCollections.toList()
                         )
                         showFavoriteDialog = false
                         favoriteRefreshToken += 1
+                        pendingFavoriteDownloadAfterSync = creationOutcome == FavoriteCreationOutcome.Created
                         if (target.supportsRemoteWebsiteSync() && appSettingsRepository.favoriteAddSyncPromptEnabled.getValue()) {
                             showFavoriteAddSyncConfirm = true
                         } else {
@@ -5410,115 +5443,6 @@ private fun ThreadReaderProgressOverlay(
         visible = showHint,
         modifier = hintModifier,
     )
-}
-
-@Composable
-@OptIn(ExperimentalMaterial3Api::class)
-private fun ReaderDownloadSheet(
-    onDismiss: () -> Unit,
-    showDownloadPage: Boolean,
-    showDownloadThread: Boolean,
-    showDownloadThreadExceptLastPage: Boolean,
-    showClearPage: Boolean,
-    showClearThread: Boolean,
-    onDownloadPage: () -> Unit,
-    onDownloadThread: () -> Unit,
-    onDownloadThreadExceptLastPage: () -> Unit,
-    onClearPage: () -> Unit,
-    onClearThread: () -> Unit,
-) {
-    val colors = YamiboTheme.colors
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        containerColor = colors.creamSurface,
-        sheetState = sheetState,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Text(i18n("下載"), color = colors.textStrong, fontSize = 22.sp)
-            Text(
-                text = i18n("下載會保存整頁帖子與原始圖片。"),
-                color = colors.textDark.copy(alpha = 0.68f),
-                fontSize = 13.sp,
-            )
-            if (showDownloadPage) {
-                DownloadSheetAction(i18n("下載目前頁"), i18n("保存此頁所有帖子與圖片"), false, onDownloadPage)
-            }
-            if (showDownloadThread) {
-                DownloadSheetAction(i18n("下載完整 Thread"), i18n("將全部頁面加入背景佇列"), false, onDownloadThread)
-            }
-            if (showDownloadThreadExceptLastPage) {
-                DownloadSheetAction(
-                    i18n("下載除最後一頁的所有頁面"),
-                    i18n("保留可能持續更新的最後一頁在線閱讀"),
-                    false,
-                    onDownloadThreadExceptLastPage,
-                )
-            }
-            if (showClearPage) {
-                DownloadSheetAction(i18n("清除目前頁下載"), i18n("只刪除此頁離線內容"), true, onClearPage)
-            }
-            if (showClearThread) {
-                DownloadSheetAction(
-                    i18n("清除整個 Thread 下載"),
-                    i18n("取消佇列並刪除所有已下載頁"),
-                    true,
-                    onClearThread
-                )
-            }
-            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
-                Text(i18n("關閉"), color = colors.brownPrimary)
-            }
-        }
-    }
-}
-
-@Composable
-private fun DownloadSheetAction(
-    title: String,
-    subtitle: String,
-    destructive: Boolean,
-    onClick: () -> Unit,
-) {
-    val colors = YamiboTheme.colors
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
-        colors = CardDefaults.cardColors(containerColor = colors.creamBackground),
-        onClick = onClick,
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                imageVector = YamiboIcons.Download,
-                contentDescription = null,
-                tint = if (destructive) colors.redAccent else colors.orangeAccent,
-                modifier = Modifier.size(22.dp),
-            )
-            Column(Modifier.padding(start = 12.dp)) {
-                Text(
-                    text = title,
-                    color = if (destructive) colors.redAccent else colors.textStrong,
-                    fontSize = 15.sp,
-                )
-                Text(
-                    text = subtitle,
-                    color = colors.textDark.copy(alpha = 0.65f),
-                    fontSize = 12.sp,
-                )
-            }
-        }
-    }
 }
 
 @Composable

--- a/composeApp/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadTest.kt
+++ b/composeApp/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/favorite/FavoritePostAddDownloadTest.kt
@@ -1,0 +1,29 @@
+package me.thenano.yamibo.yamibo_app.favorite
+
+import io.github.littlesurvival.dto.value.TagId
+import io.github.littlesurvival.dto.value.ThreadId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import me.thenano.yamibo.yamibo_app.repository.ReadHistoryRepository
+
+class FavoritePostAddDownloadTest {
+    @Test
+    fun mapsEachFavoriteTargetToItsExistingDownloadSurface() {
+        val thread = FavoriteTargetPayload.Thread(
+            tid = ThreadId(1),
+            title = "thread",
+            threadType = ReadHistoryRepository.ThreadEntryType.Normal,
+            authorId = null,
+            coverUrl = null,
+            lastUpdatedTime = null,
+            forumId = null,
+            forumName = null,
+        )
+        val tag = FavoriteTargetPayload.TagManga(TagId(2), "tag", null)
+        val rss = FavoriteTargetPayload.RssSearch(3, "rss")
+
+        assertEquals(FavoritePostAddDownloadSurface.ThreadReader, thread.postAddDownloadSurface())
+        assertEquals(FavoritePostAddDownloadSurface.TagCatalog, tag.postAddDownloadSurface())
+        assertEquals(FavoritePostAddDownloadSurface.RssCatalog, rss.postAddDownloadSurface())
+    }
+}

--- a/i18n/glossary.csv
+++ b/i18n/glossary.csv
@@ -854,6 +854,11 @@ RSS搜尋目錄(#{}),RSS search directory (#{}),RSS搜尋目錄(#{}),RSS搜尋�
 App 啟動時同步,Sync on app start,App 啟動時同步,App 启动时同步
 離開前台時同步,Sync when leaving foreground,離開前台時同步,离开前台时同步
 背景同步週期,Background sync interval,背景同步週期,后台同步周期
+收藏後顯示下載選項,Show download options after favoriting,收藏後顯示下載選項,收藏后显示下载选项
+開啟後，新增收藏完成時會顯示適用的下載選項。,"When enabled, applicable download options appear after a favorite is added.",開啟後，新增收藏完成時會顯示適用的下載選項。,开启后，新增收藏完成时会显示适用的下载选项。
+不要再詢問,Don't ask again,不要再詢問,不再询问
+可在收藏設定重新開啟。,You can enable this again in Favorite settings.,可在收藏設定重新開啟。,可在收藏设置中重新开启。
+找不到剛新增的收藏,The newly added favorite could not be found.,找不到剛新增的收藏,找不到刚新增的收藏
 下載資料夾,Download folder,下載資料夾,下载文件夹
 下載與備份資料夾,Download and backup folder,下載與備份資料夾,下载与备份文件夹
 下載內容與本地備份共用此資料夾；點擊可選擇或變更位置。,"Downloads and local backups share this folder; tap to select or change its location.",下載內容與本地備份共用此資料夾；點擊可選擇或變更位置。,下载内容与本地备份共用此文件夹；点击可选择或更改位置。

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepository.kt
@@ -192,6 +192,12 @@ class AppSettingsRepository(store: SettingsStore) : SettingsRegistry(store, pref
         default = true,
     )
 
+    /** 新增收藏後顯示下載選項 */
+    val favoriteAddDownloadPromptEnabled by boolSetting(
+        name = "favorite_add_download_prompt_enabled",
+        default = true,
+    )
+
     /** 新增收藏預設動作 */
     val favoriteAddSyncDefault by boolSetting(
         name = "favorite_add_sync_default",

--- a/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepositoryTest.kt
@@ -4,6 +4,7 @@ import me.thenano.yamibo.yamibo_app.store.settings.SettingsStore
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import me.thenano.yamibo.yamibo_app.util.time.FixedScheduleInterval
 
 class AppSettingsRepositoryTest {
@@ -13,6 +14,19 @@ class AppSettingsRepositoryTest {
 
         assertFalse(repository.favoriteUpdateAutoDownload.getValue())
         assertFalse(repository.downloadedContentRefreshAutoUpdate.getValue())
+    }
+
+    @Test
+    fun favoriteAddDownloadPromptDefaultsEnabledAndPersists() {
+        val store = AppSettingsMemoryStore()
+        val repository = AppSettingsRepository(store)
+
+        assertTrue(repository.favoriteAddDownloadPromptEnabled.getValue())
+        repository.favoriteAddDownloadPromptEnabled.setValue(false)
+
+        assertFalse(AppSettingsRepository(store).favoriteAddDownloadPromptEnabled.getValue())
+        repository.favoriteAddDownloadPromptEnabled.setValue(true)
+        assertTrue(AppSettingsRepository(store).favoriteAddDownloadPromptEnabled.getValue())
     }
 
     @Test


### PR DESCRIPTION
## Problem and root cause
Adding a favorite completed silently even when the same content supported offline download. Users had to discover and reopen a separate download action afterward. The existing download sheets were tied to their original screens and favorite creation did not expose whether an item was newly created, so the app could not safely trigger a one-time prompt.

## Implementation and design decisions
- Return an explicit creation outcome from favorite saves so prompts appear only for newly created favorites.
- Reuse the existing thread and catalog download UI instead of introducing a second set of download actions.
- Show applicable download options from every supported favorite entry point: thread reader, novel detail, tag catalog, RSS catalog, search, and reading history.
- Add a checked-state "Don't ask again" control using the app brown/cream palette.
- Persist a default-enabled Favorite setting so users can re-enable prompts later.
- Keep batch-download result formatting shared and extract the reader download sheet for reuse.
- Add repository behavior tests and Android source-contract tests for entry points, settings, UI reuse, and checkbox colors.

## User-visible behavior
After a new favorite is saved, the existing download options sheet opens for supported content. Choosing "Don't ask again" disables future prompts without starting a download; Settings > Favorite Management can turn the behavior back on. Existing favorites do not trigger the prompt again.

## Verification
- `./gradlew.bat :composeApp:compileDebugKotlinAndroid :shared:testDebugUnitTest :composeApp:testDebugUnitTest --console=plain`
- Android Pixel 9 emulator: verified post-favorite sheets across supported surfaces, the Favorite setting, and the checked checkbox color/state.
- Android crash buffer/logcat contained no fatal entries during the verified flows.
- `git diff --check`
- `git diff --name-only main...HEAD -- openspec/` returned no files.

## Risks, limits, and rollback
The main risk is duplicate or inappropriate prompting from alternate favorite entry points. Creation-outcome checks and contract tests constrain this behavior. Existing download queue and storage validation paths are reused. Rollback is the merge commit revert; saved favorites and downloads remain intact.