### PR TITLE
feat: add periodic message notifications

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -43,6 +43,9 @@
         <receiver
                 android:name=".profile.settings.sign.SignReminderActionReceiver"
                 android:exported="false" />
+        <receiver
+                android:name=".notification.MessageNotificationActionReceiver"
+                android:exported="false" />
         <provider
                 android:name="androidx.core.content.FileProvider"
                 android:authorities="${applicationId}.fileprovider"

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/MainActivity.kt
@@ -39,6 +39,9 @@ import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
 import me.thenano.yamibo.yamibo_app.navigation.rememberRestorableNavigator
 import me.thenano.yamibo.yamibo_app.network.AndroidYamiboClientProvider
 import me.thenano.yamibo.yamibo_app.notification.dismissActiveSignReminder
+import me.thenano.yamibo.yamibo_app.notification.AndroidMessageNotificationScheduler
+import me.thenano.yamibo.yamibo_app.notification.dismissActiveMessageNotification
+import me.thenano.yamibo.yamibo_app.notification.requestOpenMessageCenterFromNotification
 import me.thenano.yamibo.yamibo_app.profile.settings.access.AndroidBackgroundAccessRepository
 import me.thenano.yamibo.yamibo_app.profile.settings.backup.AndroidBackupScheduler
 import me.thenano.yamibo.yamibo_app.profile.settings.sign.AndroidSignReminderScheduler
@@ -96,6 +99,11 @@ class MainActivity : ComponentActivity() {
             dismissActiveSignReminder(this)
             showSignWebViewTrigger.value = true
             intent.putExtra(EXTRA_FROM_NOTIFICATION_SIGN_IN, false)
+        }
+        if (intent?.getBooleanExtra(EXTRA_FROM_MESSAGE_NOTIFICATION, false) == true) {
+            dismissActiveMessageNotification(this)
+            requestOpenMessageCenterFromNotification()
+            intent.putExtra(EXTRA_FROM_MESSAGE_NOTIFICATION, false)
         }
     }
 
@@ -328,6 +336,7 @@ class MainActivity : ComponentActivity() {
             }
             val backupScheduler = remember { AndroidBackupScheduler(context) }
             val signReminderScheduler = remember { AndroidSignReminderScheduler(context) }
+            val messageNotificationScheduler = remember { AndroidMessageNotificationScheduler(context) }
             LaunchedEffect(backupRepository) {
                 diskCacheFactory.backupStorageUsageProvider = { backupRepository.getBackupStorageBytes() }
             }
@@ -407,6 +416,8 @@ class MainActivity : ComponentActivity() {
                 val favoriteUpdateInterval = appSettingsRepository.favoriteUpdateInterval.state()
                 val backupInterval = appSettingsRepository.backupInterval.state()
                 val signReminderFrequency = appSettingsRepository.signInReminderFrequency.state()
+                val messageNotificationEnabled = appSettingsRepository.messageNotificationEnabled.state()
+                val messageNotificationInterval = appSettingsRepository.messageNotificationInterval.state()
                 
                 LaunchedEffect(Unit) {
                     if (appSettingsRepository.clearCacheOnAppLaunch.getValue()) {
@@ -425,6 +436,13 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(signReminderFrequency) {
                     delay(1_200.milliseconds)
                     signReminderScheduler.schedule(signReminderFrequency)
+                }
+                LaunchedEffect(messageNotificationEnabled, messageNotificationInterval) {
+                    delay(1_200.milliseconds)
+                    messageNotificationScheduler.setEnabled(
+                        enabled = messageNotificationEnabled,
+                        interval = messageNotificationInterval,
+                    )
                 }
                 LaunchedEffect(Unit) {
                     delay(1_200.milliseconds)
@@ -448,5 +466,6 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_FROM_NOTIFICATION_SIGN_IN = "extra_from_notification_sign_in"
+        const val EXTRA_FROM_MESSAGE_NOTIFICATION = "extra_from_message_notification"
     }
 }

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationGateway.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationGateway.kt
@@ -1,0 +1,95 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import me.thenano.yamibo.yamibo_app.Logger
+import me.thenano.yamibo.yamibo_app.MainActivity
+import me.thenano.yamibo.yamibo_app.i18n.i18n
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationGateway
+
+internal class AndroidMessageNotificationGateway(context: Context) : MessageNotificationGateway {
+    private val appContext = context.applicationContext
+    private val manager = NotificationManagerCompat.from(appContext)
+
+    override suspend fun showMessageNotification(): Boolean {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) return false
+        if (!manager.areNotificationsEnabled()) return false
+
+        ensureChannel()
+        val openPendingIntent = PendingIntent.getActivity(
+            appContext,
+            REQUEST_CODE_OPEN,
+            Intent(appContext, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(MainActivity.EXTRA_FROM_MESSAGE_NOTIFICATION, true)
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val mutePendingIntent = PendingIntent.getBroadcast(
+            appContext,
+            REQUEST_CODE_MUTE,
+            Intent(appContext, MessageNotificationActionReceiver::class.java).apply {
+                action = MessageNotificationActionReceiver.ACTION_MUTE_TODAY
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(AndroidNotificationMetadata.SMALL_ICON_RES_ID)
+            .setContentTitle(i18n("新消息通知"))
+            .setContentText("您有新的通知，快來看看吧 !")
+            .setAutoCancel(true)
+            .setContentIntent(openPendingIntent)
+            .addAction(0, "查看通知", openPendingIntent)
+            .addAction(0, "不再提醒（僅限今日）", mutePendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+        return try {
+            manager.notify(NOTIFICATION_ID, notification)
+            true
+        } catch (error: SecurityException) {
+            Logger.e("MessageNotification", "Notification permission was revoked", error)
+            false
+        }
+    }
+
+    override suspend fun dismissMessageNotification() {
+        manager.cancel(NOTIFICATION_ID)
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        (appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+            .createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    i18n("新消息通知"),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+    }
+
+    companion object {
+        const val CHANNEL_ID = "message_notification_channel"
+        const val NOTIFICATION_ID = 228150
+        private const val REQUEST_CODE_OPEN = 1050
+        private const val REQUEST_CODE_MUTE = 1051
+    }
+}
+
+internal fun dismissActiveMessageNotification(context: Context) {
+    NotificationManagerCompat.from(context.applicationContext)
+        .cancel(AndroidMessageNotificationGateway.NOTIFICATION_ID)
+}

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationRuntime.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationRuntime.kt
@@ -1,0 +1,30 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import android.content.Context
+import me.thenano.yamibo.yamibo_app.network.AndroidYamiboClientProvider
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationChecker
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationDeliveryStateStore
+import me.thenano.yamibo.yamibo_app.repository.settings.AppSettingsRepository
+import me.thenano.yamibo.yamibo_app.store.AndroidCookieStore
+import me.thenano.yamibo.yamibo_app.store.AndroidUserStore
+import me.thenano.yamibo.yamibo_app.store.settings.AndroidSettingsStore
+
+internal object AndroidMessageNotificationRuntime {
+    fun createChecker(context: Context): MessageNotificationChecker {
+        val appContext = context.applicationContext
+        val rawSettings = AndroidSettingsStore(appContext)
+        val cookieStore = AndroidCookieStore(appContext)
+        val userStore = AndroidUserStore(appContext)
+        val client = AndroidYamiboClientProvider.get(appContext)
+        return MessageNotificationChecker(
+            settings = AppSettingsRepository(rawSettings),
+            deliveryStateStore = MessageNotificationDeliveryStateStore(rawSettings),
+            currentUserId = { userStore.load()?.uid?.value },
+            fetchHomePage = {
+                client.setCookie(cookieStore.load().orEmpty())
+                client.fetchHomePage()
+            },
+            notificationGateway = AndroidMessageNotificationGateway(appContext),
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationScheduler.kt
@@ -1,0 +1,40 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import me.thenano.yamibo.yamibo_app.util.time.FixedScheduleInterval
+import kotlin.time.toJavaDuration
+
+internal class AndroidMessageNotificationScheduler(context: Context) {
+    private val workManager = WorkManager.getInstance(context.applicationContext)
+
+    fun setEnabled(enabled: Boolean, interval: FixedScheduleInterval) {
+        if (!enabled) {
+            workManager.cancelUniqueWork(UNIQUE_PERIODIC_WORK)
+            return
+        }
+        val request = PeriodicWorkRequestBuilder<MessageNotificationWorker>(interval.duration.toJavaDuration())
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .build(),
+            )
+            .addTag(WORK_TAG)
+            .build()
+        workManager.enqueueUniquePeriodicWork(
+            UNIQUE_PERIODIC_WORK,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+
+    companion object {
+        const val WORK_TAG = "message-notification-check"
+        const val UNIQUE_PERIODIC_WORK = "message-notification-check-periodic"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationActionReceiver.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationActionReceiver.kt
@@ -1,0 +1,27 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+internal class MessageNotificationActionReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != ACTION_MUTE_TODAY) return
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                AndroidMessageNotificationRuntime.createChecker(context).muteToday()
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_MUTE_TODAY =
+            "me.thenano.yamibo.yamibo_app.action.MUTE_MESSAGE_NOTIFICATIONS_TODAY"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationWorker.kt
+++ b/composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationWorker.kt
@@ -1,0 +1,38 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import me.thenano.yamibo.yamibo_app.Logger
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationChecker
+
+internal class MessageNotificationWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result = try {
+        when (val checkResult = AndroidMessageNotificationRuntime.createChecker(applicationContext).check()) {
+            is MessageNotificationChecker.Result.FetchFailed -> {
+                if (shouldRetryMessageCheck(checkResult, runAttemptCount)) {
+                    Result.retry()
+                } else {
+                    Result.success()
+                }
+            }
+            else -> Result.success()
+        }
+    } catch (error: Throwable) {
+        Logger.e(TAG, "Periodic message check failed", error)
+        if (runAttemptCount < MAX_RETRIES) Result.retry() else Result.failure()
+    }
+
+    companion object {
+        const val TAG = "MessageNotificationWorker"
+        const val MAX_RETRIES = 3
+    }
+}
+
+internal fun shouldRetryMessageCheck(
+    result: MessageNotificationChecker.Result.FetchFailed,
+    runAttemptCount: Int,
+): Boolean = result.retryable && runAttemptCount < MessageNotificationWorker.MAX_RETRIES

--- a/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/notification/AndroidMessageNotificationContractTest.kt
@@ -1,0 +1,76 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationChecker
+
+class AndroidMessageNotificationContractTest {
+    @Test
+    fun workerRetriesOnlyBoundedRetryableFailures() {
+        assertTrue(
+            shouldRetryMessageCheck(
+                MessageNotificationChecker.Result.FetchFailed(retryable = true),
+                runAttemptCount = 0,
+            ),
+        )
+        assertFalse(
+            shouldRetryMessageCheck(
+                MessageNotificationChecker.Result.FetchFailed(retryable = false),
+                runAttemptCount = 0,
+            ),
+        )
+        assertFalse(
+            shouldRetryMessageCheck(
+                MessageNotificationChecker.Result.FetchFailed(retryable = true),
+                runAttemptCount = MessageNotificationWorker.MAX_RETRIES,
+            ),
+        )
+    }
+
+    @Test
+    fun schedulerUsesOnePeriodicWorkWithRequiredConstraints() {
+        val source = androidSource("notification/AndroidMessageNotificationScheduler.kt")
+
+        assertTrue(source.contains("UNIQUE_PERIODIC_WORK = \"message-notification-check-periodic\""))
+        assertTrue(source.contains("ExistingPeriodicWorkPolicy.UPDATE"))
+        assertTrue(source.contains("NetworkType.CONNECTED"))
+        assertTrue(source.contains("setRequiresBatteryNotLow(true)"))
+        assertTrue(source.contains("cancelUniqueWork(UNIQUE_PERIODIC_WORK)"))
+    }
+
+    @Test
+    fun notificationHasFixedBodyBothActionsAndDedicatedMetadata() {
+        val source = androidSource("notification/AndroidMessageNotificationGateway.kt")
+
+        assertTrue(source.contains(".setContentText(\"您有新的通知，快來看看吧 !\")"))
+        assertTrue(source.contains(".addAction(0, \"查看通知\""))
+        assertTrue(source.contains(".addAction(0, \"不再提醒（僅限今日）\""))
+        assertTrue(source.contains("message_notification_channel"))
+        assertEquals(1, Regex("const val NOTIFICATION_ID = 228150").findAll(source).count())
+    }
+
+    @Test
+    fun receiverAndWarmColdRoutingAreRegistered() {
+        val manifest = projectFile("composeApp/src/androidMain/AndroidManifest.xml").readText(Charsets.UTF_8)
+        val activity = androidSource("MainActivity.kt")
+        val receiver = androidSource("notification/MessageNotificationActionReceiver.kt")
+
+        assertTrue(manifest.contains(".notification.MessageNotificationActionReceiver"))
+        assertTrue(activity.contains("EXTRA_FROM_MESSAGE_NOTIFICATION"))
+        assertTrue(activity.contains("requestOpenMessageCenterFromNotification()"))
+        assertTrue(receiver.contains("createChecker(context).muteToday()"))
+    }
+
+    private fun androidSource(relativePath: String): String = projectFile(
+        "composeApp/src/androidMain/kotlin/me/thenano/yamibo/yamibo_app/$relativePath",
+    ).readText(Charsets.UTF_8)
+
+    private fun projectFile(relativePath: String): File {
+        val root = generateSequence(File(System.getProperty("user.dir") ?: ".")) { it.parentFile }
+            .first { File(it, "composeApp/src/androidMain").isDirectory }
+        return File(root, relativePath)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/notification/IOSMessageNotificationContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/notification/IOSMessageNotificationContractTest.kt
@@ -1,0 +1,51 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class IOSMessageNotificationContractTest {
+    @Test
+    fun plistAndSchedulerUseDedicatedRefreshRegistration() {
+        val plist = projectFile("iosApp/iosApp/Info.plist").readText(Charsets.UTF_8)
+        val kotlin = iosSource("notification/IOSMessageNotificationBackground.kt")
+        val swift = projectFile("iosApp/iosApp/iOSApp.swift").readText(Charsets.UTF_8)
+
+        assertTrue(plist.contains("me.thenano.yamibo.yamibo-app.message-notification"))
+        assertTrue(plist.contains("<string>fetch</string>"))
+        assertTrue(kotlin.contains("BGAppRefreshTaskRequest"))
+        assertTrue(kotlin.contains("interval.duration.inWholeSeconds"))
+        assertTrue(kotlin.contains("cancelTaskRequestWithIdentifier"))
+        assertTrue(swift.contains("BGAppRefreshTask"))
+        assertTrue(swift.contains("guard !completed else { return }"))
+        assertTrue(swift.contains("expirationHandler"))
+    }
+
+    @Test
+    fun localNotificationAndExportedActionBridgesAreWired() {
+        val kotlin = iosSource("notification/IOSMessageNotificationBackground.kt")
+        val swift = projectFile("iosApp/iosApp/iOSApp.swift").readText(Charsets.UTF_8)
+        val permission = iosSource("profile/settings/access/BackgroundAccessPlatformSupport.ios.kt")
+
+        assertTrue(kotlin.contains("setBody(\"您有新的通知，快來看看吧 !\")"))
+        assertTrue(kotlin.contains("UNAuthorizationStatusAuthorized"))
+        assertTrue(kotlin.contains("fun openMessageCenterFromIOSNotification()"))
+        assertTrue(kotlin.contains("fun muteMessageNotificationsToday"))
+        assertTrue(swift.contains("查看通知"))
+        assertTrue(swift.contains("不再提醒（僅限今日）"))
+        assertTrue(swift.contains("openMessageCenterFromIOSNotification"))
+        assertTrue(swift.contains("muteMessageNotificationsToday"))
+        assertTrue(permission.contains("UNAuthorizationStatusNotDetermined"))
+        assertTrue(permission.contains("requestAuthorizationWithOptions"))
+    }
+
+    private fun iosSource(relativePath: String): String = projectFile(
+        "composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/$relativePath",
+    ).readText(Charsets.UTF_8)
+
+    private fun projectFile(relativePath: String): File {
+        val root = generateSequence(File(System.getProperty("user.dir") ?: ".")) { it.parentFile }
+            .first { File(it, "composeApp/src/iosMain").isDirectory }
+        return File(root, relativePath)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/MessageNotificationSettingsUiContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/MessageNotificationSettingsUiContractTest.kt
@@ -1,0 +1,31 @@
+package me.thenano.yamibo.yamibo_app.profile.settings.access
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MessageNotificationSettingsUiContractTest {
+    @Test
+    fun backgroundAccessScreenReusesSettingsControlsAndShowsBothSelectorsFirst() {
+        val source = source("profile/settings/access/BackgroundAccessSetupScreen.kt")
+
+        assertTrue(source.contains("SettingsToggleRow("))
+        assertTrue(source.contains("SettingsChipRow("))
+        assertTrue(source.contains("MessageNotificationIntervals.map"))
+        assertTrue(source.contains("MessageNotificationDailyLimit.entries.map"))
+        assertTrue(source.count { it == '\n' } > 0)
+        assertTrue(source.countOccurrences("enabled = messageNotificationsEnabled") == 2)
+        assertTrue(source.indexOf("新消息通知") < source.indexOf("系統存取狀態"))
+    }
+
+    private fun source(relativePath: String): String {
+        val root = generateSequence(File(System.getProperty("user.dir") ?: ".")) { it.parentFile }
+            .first { File(it, "composeApp/src/commonMain/kotlin").isDirectory }
+        return File(
+            root,
+            "composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/$relativePath",
+        ).readText(Charsets.UTF_8)
+    }
+
+    private fun String.countOccurrences(value: String): Int = windowed(value.length).count { it == value }
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/App.kt
@@ -55,6 +55,9 @@ import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.ComposableNavigator
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
 import me.thenano.yamibo.yamibo_app.navigation.NavAction
+import me.thenano.yamibo.yamibo_app.message.IMessageCenterScreen
+import me.thenano.yamibo.yamibo_app.message.MessageCenterTab
+import me.thenano.yamibo.yamibo_app.notification.messageNotificationNavigationTrigger
 import me.thenano.yamibo.yamibo_app.profile.settings.update.AppUpdatePromptContent
 import me.thenano.yamibo.yamibo_app.profile.sign.ISignWebView
 import me.thenano.yamibo.yamibo_app.profile.sign.shouldDismissSignReminderFor
@@ -356,6 +359,15 @@ fun App() {
                 signRepository = signRepository,
                 appTaskManager = appTaskManager,
                 feedbackController = feedbackController,
+            )
+        }
+    }
+
+    val openMessageCenterFromNotification by messageNotificationNavigationTrigger.pending.collectAsState()
+    LaunchedEffect(openMessageCenterFromNotification) {
+        if (openMessageCenterFromNotification && messageNotificationNavigationTrigger.consume()) {
+            navigator.navigate(
+                IMessageCenterScreen(initialTab = MessageCenterTab.PrivateMessages),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/i18n/SettingsOptionLabels.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/i18n/SettingsOptionLabels.kt
@@ -82,3 +82,13 @@ fun SignReminderFrequency.localizedLabel(): String = when (this) {
     SignReminderFrequency.SIX_TIMES_A_DAY -> i18n("每天 6 次")
 }
 
+fun MessageNotificationDailyLimit.localizedLabel(): String = when (this) {
+    MessageNotificationDailyLimit.ONCE -> i18n("每天 1 次")
+    MessageNotificationDailyLimit.TWICE -> i18n("每天 2 次")
+    MessageNotificationDailyLimit.THREE_TIMES -> i18n("每天 3 次")
+    MessageNotificationDailyLimit.FOUR_TIMES -> i18n("每天 4 次")
+    MessageNotificationDailyLimit.FIVE_TIMES -> i18n("每天 5 次")
+    MessageNotificationDailyLimit.SIX_TIMES -> i18n("每天 6 次")
+    MessageNotificationDailyLimit.UNLIMITED -> i18n("無上限")
+}
+

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationNavigation.kt
@@ -1,0 +1,26 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class MessageNotificationNavigationTrigger {
+    private val _pending = MutableStateFlow(false)
+    val pending: StateFlow<Boolean> = _pending.asStateFlow()
+
+    fun requestOpen() {
+        _pending.value = true
+    }
+
+    fun consume(): Boolean {
+        if (!_pending.value) return false
+        _pending.value = false
+        return true
+    }
+}
+
+internal val messageNotificationNavigationTrigger = MessageNotificationNavigationTrigger()
+
+fun requestOpenMessageCenterFromNotification() {
+    messageNotificationNavigationTrigger.requestOpen()
+}

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
@@ -31,6 +31,7 @@ import me.thenano.yamibo.yamibo_app.profile.settings.access.IBackgroundAccessSet
 import me.thenano.yamibo.yamibo_app.profile.settings.backup.rememberBackupFileActions
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.*
 import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsChipRow
+import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsToggleRow
 import me.thenano.yamibo.yamibo_app.profile.settings.components.ThemeSelectorContent
 import me.thenano.yamibo.yamibo_app.repository.FavoriteSyncRepository.FavoriteSyncState
 import me.thenano.yamibo.yamibo_app.repository.download.DownloadedContentSummary
@@ -478,38 +479,6 @@ private fun FavoriteSettingsContent(feedbackController: me.thenano.yamibo.yamibo
             fontSize = 13.sp,
             color = colors.textDark.copy(alpha = 0.68f),
             modifier = Modifier.padding(horizontal = 4.dp),
-        )
-    }
-}
-
-@Composable
-private fun SettingsToggleRow(
-    title: String,
-    subtitle: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    val colors = YamiboTheme.colors
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) { onCheckedChange(!checked) }
-            .padding(vertical = 16.dp, horizontal = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        SettingsRowDescription(title = title, subtitle = subtitle, colors = colors)
-        Switch(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = colors.brownDeep,
-                checkedTrackColor = colors.brownPrimary.copy(alpha = 0.5f),
-                uncheckedThumbColor = colors.textDark.copy(alpha = 0.5f),
-                uncheckedTrackColor = colors.brownLight.copy(alpha = 0.3f),
-            ),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/BackgroundAccessSetupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/BackgroundAccessSetupScreen.kt
@@ -18,17 +18,28 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import me.thenano.yamibo.yamibo_app.LocalBackgroundAccessRepository
+import me.thenano.yamibo.yamibo_app.LocalAppSettingsRepository
 import me.thenano.yamibo.yamibo_app.components.navigation.YamiboTopBar
 import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
 import me.thenano.yamibo.yamibo_app.i18n.i18n
+import me.thenano.yamibo.yamibo_app.i18n.localizedLabel
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
+import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsChipRow
+import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsToggleRow
+import me.thenano.yamibo.yamibo_app.repository.settings.MessageNotificationDailyLimit
+import me.thenano.yamibo.yamibo_app.repository.settings.MessageNotificationIntervals
+import me.thenano.yamibo.yamibo_app.util.state
 
 @Composable
 internal fun BackgroundAccessSetupScreen() {
     val colors = YamiboTheme.colors
     val navigator = LocalNavigator.current
     val repository = LocalBackgroundAccessRepository.current
+    val appSettings = LocalAppSettingsRepository.current
     val state by repository.state.collectAsState()
+    val messageNotificationsEnabled = appSettings.messageNotificationEnabled.state()
+    val messageNotificationInterval = appSettings.messageNotificationInterval.state()
+    val messageNotificationDailyLimit = appSettings.messageNotificationDailyLimit.state()
     val coroutineScope = rememberCoroutineScope()
     val notificationPermissionRequester = rememberBackgroundAccessNotificationPermissionRequester {
         coroutineScope.launch {
@@ -62,6 +73,68 @@ internal fun BackgroundAccessSetupScreen() {
                 .verticalScroll(rememberScrollState())
                 .padding(20.dp),
         ) {
+            Text(
+                text = i18n("新消息通知"),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.textDark.copy(alpha = 0.5f),
+            )
+            Spacer(Modifier.height(6.dp))
+            SettingsToggleRow(
+                title = i18n("定時檢查新消息"),
+                subtitle = i18n("在背景讀取首頁的消息紅點，發現新消息時顯示系統通知。"),
+                checked = messageNotificationsEnabled,
+                onCheckedChange = appSettings.messageNotificationEnabled::setValue,
+            )
+
+            Text(
+                text = i18n("檢查週期"),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = colors.textDark,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+            Spacer(Modifier.height(6.dp))
+            SettingsChipRow(
+                options = MessageNotificationIntervals.map { it to it.localizedLabel() },
+                selectedValue = messageNotificationInterval,
+                onSelect = appSettings.messageNotificationInterval::setValue,
+                modifier = Modifier.padding(horizontal = 4.dp),
+                enabled = messageNotificationsEnabled,
+            )
+
+            Spacer(Modifier.height(18.dp))
+            Text(
+                text = i18n("每日通知次數上限"),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = colors.textDark,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+            Spacer(Modifier.height(6.dp))
+            SettingsChipRow(
+                options = MessageNotificationDailyLimit.entries.map { it to it.localizedLabel() },
+                selectedValue = messageNotificationDailyLimit,
+                onSelect = appSettings.messageNotificationDailyLimit::setValue,
+                modifier = Modifier.padding(horizontal = 4.dp),
+                enabled = messageNotificationsEnabled,
+            )
+            Text(
+                text = i18n("通知內容不包含消息正文；iOS 的實際檢查時間由系統決定。"),
+                fontSize = 13.sp,
+                color = colors.textDark.copy(alpha = 0.68f),
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(start = 4.dp, top = 12.dp, end = 4.dp),
+            )
+
+            Spacer(Modifier.height(32.dp))
+            Text(
+                text = i18n("系統存取狀態"),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.textDark.copy(alpha = 0.5f),
+            )
+            Spacer(Modifier.height(12.dp))
             Text(
                 text = state.summary.localized(),
                 fontSize = 16.sp,

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/components/SettingsChipRow.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/components/SettingsChipRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -21,14 +22,15 @@ fun <T> SettingsChipRow(
     options: List<Pair<T, String>>,
     selectedValue: T,
     onSelect: (T) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     val colors = YamiboTheme.colors
 
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier
+        modifier = modifier.graphicsLayer { alpha = if (enabled) 1f else 0.42f }
     ) {
         options.forEach { (value, label) ->
             val isSelected = value == selectedValue
@@ -42,7 +44,7 @@ fun <T> SettingsChipRow(
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
-                    ) { onSelect(value) }
+                    ) { if (enabled) onSelect(value) }
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text(

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/components/SettingsToggleRow.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/components/SettingsToggleRow.kt
@@ -1,0 +1,66 @@
+package me.thenano.yamibo.yamibo_app.profile.settings.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.thenano.yamibo.yamibo_app.components.theme.YamiboTheme
+
+@Composable
+fun SettingsToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val colors = YamiboTheme.colors
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .graphicsLayer { alpha = if (enabled) 1f else 0.42f }
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { if (enabled) onCheckedChange(!checked) }
+            .padding(vertical = 16.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = colors.textDark,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                fontSize = 13.sp,
+                color = colors.textDark.copy(alpha = 0.6f),
+            )
+        }
+        Switch(
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = colors.brownDeep,
+                checkedTrackColor = colors.brownPrimary.copy(alpha = 0.5f),
+                uncheckedThumbColor = colors.textDark.copy(alpha = 0.5f),
+                uncheckedTrackColor = colors.brownLight.copy(alpha = 0.3f),
+            ),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationNavigationTriggerTest.kt
+++ b/composeApp/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/notification/MessageNotificationNavigationTriggerTest.kt
@@ -1,0 +1,19 @@
+package me.thenano.yamibo.yamibo_app.notification
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MessageNotificationNavigationTriggerTest {
+    @Test
+    fun requestIsConsumedExactlyOnce() {
+        val trigger = MessageNotificationNavigationTrigger()
+
+        assertFalse(trigger.pending.value)
+        trigger.requestOpen()
+        assertTrue(trigger.pending.value)
+        assertTrue(trigger.consume())
+        assertFalse(trigger.pending.value)
+        assertFalse(trigger.consume())
+    }
+}

--- a/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/MainViewController.kt
@@ -21,6 +21,8 @@ import me.thenano.yamibo.yamibo_app.i18n.i18n
 import me.thenano.yamibo.yamibo_app.navigation.LocalNavigator
 import me.thenano.yamibo.yamibo_app.navigation.rememberRestorableNavigator
 import me.thenano.yamibo.yamibo_app.network.IOSYamiboClientProvider
+import me.thenano.yamibo.yamibo_app.notification.IOSMessageNotificationScheduler
+import me.thenano.yamibo.yamibo_app.profile.settings.access.requestIOSNotificationAuthorizationIfNeeded
 import me.thenano.yamibo.yamibo_app.profile.settings.access.IOSBackgroundAccessRepository
 import me.thenano.yamibo.yamibo_app.profile.settings.backup.IOSBackupScheduler
 import me.thenano.yamibo.yamibo_app.profile.settings.sign.IOSSignReminderScheduler
@@ -50,6 +52,7 @@ import me.thenano.yamibo.yamibo_app.store.IOSUserStore
 import me.thenano.yamibo.yamibo_app.store.settings.IOSSettingsStore
 import me.thenano.yamibo.yamibo_app.update.IOSAppUpdatePlatform
 import me.thenano.yamibo.yamibo_app.task.AppTaskManager
+import me.thenano.yamibo.yamibo_app.util.state
 import me.thenano.yamibo.yamibo_app.confirmation.AppConfirmationController
 import me.thenano.yamibo.yamibo_app.appsync.IOSAppSyncBackgroundScheduler
 import me.thenano.yamibo.yamibo_app.appsync.AppSyncLifecycleController
@@ -255,6 +258,7 @@ fun MainViewController() = ComposeUIViewController {
             platform = IOSAppUpdatePlatform(),
         )
     }
+    val messageNotificationScheduler = remember { IOSMessageNotificationScheduler() }
 
     /** Provide Repositories */
     CompositionLocalProvider(
@@ -302,10 +306,20 @@ fun MainViewController() = ComposeUIViewController {
         LocalImageReaderModeOverrideRepository provides imageReaderModeOverrideRepository,
         LocalSignReminderScheduler provides signReminderScheduler,
     ) {
+        val messageNotificationEnabled = appSettingsRepository.messageNotificationEnabled.state()
+        val messageNotificationInterval = appSettingsRepository.messageNotificationInterval.state()
+
         androidx.compose.runtime.LaunchedEffect(Unit) {
             if (appSettingsRepository.clearCacheOnAppLaunch.getValue()) {
                 diskCacheFactory.clearAllCache()
             }
+        }
+        androidx.compose.runtime.LaunchedEffect(messageNotificationEnabled, messageNotificationInterval) {
+            messageNotificationScheduler.setEnabled(
+                enabled = messageNotificationEnabled,
+                interval = messageNotificationInterval,
+            )
+            if (messageNotificationEnabled) requestIOSNotificationAuthorizationIfNeeded()
         }
         YamiboWafRecoveryRoot(yamiboClient) {
             App()

--- a/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/notification/IOSMessageNotificationBackground.kt
+++ b/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/notification/IOSMessageNotificationBackground.kt
@@ -1,0 +1,162 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package me.thenano.yamibo.yamibo_app.notification
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import me.thenano.yamibo.yamibo_app.i18n.i18n
+import me.thenano.yamibo.yamibo_app.network.IOSYamiboClientProvider
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationChecker
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationDeliveryStateStore
+import me.thenano.yamibo.yamibo_app.repository.notification.MessageNotificationGateway
+import me.thenano.yamibo.yamibo_app.repository.settings.AppSettingsRepository
+import me.thenano.yamibo.yamibo_app.store.IOSCookieStore
+import me.thenano.yamibo.yamibo_app.store.IOSUserStore
+import me.thenano.yamibo.yamibo_app.store.settings.IOSSettingsStore
+import me.thenano.yamibo.yamibo_app.util.time.FixedScheduleInterval
+import platform.BackgroundTasks.BGAppRefreshTaskRequest
+import platform.BackgroundTasks.BGTaskScheduler
+import platform.Foundation.NSDate
+import platform.UserNotifications.UNAuthorizationStatusAuthorized
+import platform.UserNotifications.UNAuthorizationStatusProvisional
+import platform.UserNotifications.UNMutableNotificationContent
+import platform.UserNotifications.UNNotificationRequest
+import platform.UserNotifications.UNUserNotificationCenter
+import kotlin.coroutines.resume
+
+const val MESSAGE_NOTIFICATION_BACKGROUND_TASK_IDENTIFIER =
+    "me.thenano.yamibo.yamibo-app.message-notification"
+const val MESSAGE_NOTIFICATION_CATEGORY_IDENTIFIER =
+    "me.thenano.yamibo.yamibo-app.message-notification.category"
+const val MESSAGE_NOTIFICATION_OPEN_ACTION_IDENTIFIER =
+    "me.thenano.yamibo.yamibo-app.message-notification.open"
+const val MESSAGE_NOTIFICATION_MUTE_ACTION_IDENTIFIER =
+    "me.thenano.yamibo.yamibo-app.message-notification.mute-today"
+private const val MESSAGE_NOTIFICATION_REQUEST_IDENTIFIER =
+    "me.thenano.yamibo.yamibo-app.message-notification.current"
+
+class IOSMessageNotificationScheduler {
+    fun setEnabled(enabled: Boolean, interval: FixedScheduleInterval) {
+        BGTaskScheduler.sharedScheduler.cancelTaskRequestWithIdentifier(
+            MESSAGE_NOTIFICATION_BACKGROUND_TASK_IDENTIFIER,
+        )
+        if (!enabled) return
+        val request = BGAppRefreshTaskRequest(MESSAGE_NOTIFICATION_BACKGROUND_TASK_IDENTIFIER).apply {
+            earliestBeginDate = NSDate(
+                timeIntervalSinceReferenceDate =
+                    NSDate().timeIntervalSinceReferenceDate + interval.duration.inWholeSeconds.toDouble(),
+            )
+        }
+        BGTaskScheduler.sharedScheduler.submitTaskRequest(request, null)
+    }
+}
+
+private var activeMessageNotificationJob: Job? = null
+
+fun runMessageNotificationBackground(completion: (Boolean) -> Unit) {
+    activeMessageNotificationJob?.cancel()
+    activeMessageNotificationJob = CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+        val settings = AppSettingsRepository(IOSSettingsStore())
+        val result = runCatching { createIOSMessageNotificationChecker(settings).check() }.getOrNull()
+        if (settings.messageNotificationEnabled.getValue()) {
+            IOSMessageNotificationScheduler().setEnabled(
+                enabled = true,
+                interval = settings.messageNotificationInterval.getValue(),
+            )
+        }
+        completion(
+            result != null &&
+                (result !is MessageNotificationChecker.Result.FetchFailed || !result.retryable),
+        )
+        activeMessageNotificationJob = null
+    }
+}
+
+fun cancelMessageNotificationBackground() {
+    activeMessageNotificationJob?.cancel()
+    activeMessageNotificationJob = null
+    val settings = AppSettingsRepository(IOSSettingsStore())
+    if (settings.messageNotificationEnabled.getValue()) {
+        IOSMessageNotificationScheduler().setEnabled(
+            enabled = true,
+            interval = settings.messageNotificationInterval.getValue(),
+        )
+    }
+}
+
+fun openMessageCenterFromIOSNotification() {
+    requestOpenMessageCenterFromNotification()
+}
+
+fun muteMessageNotificationsToday(completion: (Boolean) -> Unit) {
+    CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+        completion(createIOSMessageNotificationActionChecker().muteToday())
+    }
+}
+
+private fun createIOSMessageNotificationActionChecker(): MessageNotificationChecker {
+    val rawSettings = IOSSettingsStore()
+    val userStore = IOSUserStore()
+    return MessageNotificationChecker(
+        settings = AppSettingsRepository(rawSettings),
+        deliveryStateStore = MessageNotificationDeliveryStateStore(rawSettings),
+        currentUserId = { userStore.load()?.uid?.value },
+        fetchHomePage = { error("Message fetch is not used by notification actions") },
+        notificationGateway = IOSMessageNotificationGateway(),
+    )
+}
+
+private suspend fun createIOSMessageNotificationChecker(
+    settings: AppSettingsRepository = AppSettingsRepository(IOSSettingsStore()),
+): MessageNotificationChecker {
+    val rawSettings = IOSSettingsStore()
+    val cookieStore = IOSCookieStore()
+    val userStore = IOSUserStore()
+    val client = IOSYamiboClientProvider.getForBackground(cookieStore)
+    return MessageNotificationChecker(
+        settings = settings,
+        deliveryStateStore = MessageNotificationDeliveryStateStore(rawSettings),
+        currentUserId = { userStore.load()?.uid?.value },
+        fetchHomePage = { client.fetchHomePage() },
+        notificationGateway = IOSMessageNotificationGateway(),
+    )
+}
+
+private class IOSMessageNotificationGateway : MessageNotificationGateway {
+    override suspend fun showMessageNotification(): Boolean = suspendCancellableCoroutine { continuation ->
+        val center = UNUserNotificationCenter.currentNotificationCenter()
+        center.getNotificationSettingsWithCompletionHandler { settings ->
+            if (
+                settings?.authorizationStatus != UNAuthorizationStatusAuthorized &&
+                settings?.authorizationStatus != UNAuthorizationStatusProvisional
+            ) {
+                if (continuation.isActive) continuation.resume(false)
+                return@getNotificationSettingsWithCompletionHandler
+            }
+            val content = UNMutableNotificationContent().apply {
+                setTitle(i18n("新消息通知"))
+                setBody("您有新的通知，快來看看吧 !")
+                setCategoryIdentifier(MESSAGE_NOTIFICATION_CATEGORY_IDENTIFIER)
+            }
+            center.addNotificationRequest(
+                UNNotificationRequest.requestWithIdentifier(
+                    identifier = MESSAGE_NOTIFICATION_REQUEST_IDENTIFIER,
+                    content = content,
+                    trigger = null,
+                ),
+            ) { error ->
+                if (continuation.isActive) continuation.resume(error == null)
+            }
+        }
+    }
+
+    override suspend fun dismissMessageNotification() {
+        val center = UNUserNotificationCenter.currentNotificationCenter()
+        center.removeDeliveredNotificationsWithIdentifiers(listOf(MESSAGE_NOTIFICATION_REQUEST_IDENTIFIER))
+        center.removePendingNotificationRequestsWithIdentifiers(listOf(MESSAGE_NOTIFICATION_REQUEST_IDENTIFIER))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/BackgroundAccessPlatformSupport.ios.kt
+++ b/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/BackgroundAccessPlatformSupport.ios.kt
@@ -1,13 +1,42 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package me.thenano.yamibo.yamibo_app.profile.settings.access
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import platform.UserNotifications.UNAuthorizationOptionAlert
+import platform.UserNotifications.UNAuthorizationOptionBadge
+import platform.UserNotifications.UNAuthorizationOptionSound
+import platform.UserNotifications.UNAuthorizationStatusNotDetermined
+import platform.UserNotifications.UNUserNotificationCenter
 
 @Composable
 actual fun rememberBackgroundAccessNotificationPermissionRequester(
     onPermissionHandled: () -> Unit,
-): (() -> Unit)? = null
+): (() -> Unit)? = remember(onPermissionHandled) {
+    {
+        requestIOSNotificationAuthorization {
+            onPermissionHandled()
+        }
+    }
+}
 
 @Composable
 actual fun BackgroundAccessResumeRefreshEffect(
     onResume: () -> Unit,
 ) = Unit
+
+fun requestIOSNotificationAuthorizationIfNeeded() {
+    val center = UNUserNotificationCenter.currentNotificationCenter()
+    center.getNotificationSettingsWithCompletionHandler { settings ->
+        if (settings?.authorizationStatus == UNAuthorizationStatusNotDetermined) {
+            requestIOSNotificationAuthorization()
+        }
+    }
+}
+
+private fun requestIOSNotificationAuthorization(onHandled: () -> Unit = {}) {
+    UNUserNotificationCenter.currentNotificationCenter().requestAuthorizationWithOptions(
+        options = UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge,
+    ) { _, _ -> onHandled() }
+}

--- a/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/IOSBackgroundAccessRepository.kt
+++ b/composeApp/src/iosMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/access/IOSBackgroundAccessRepository.kt
@@ -1,32 +1,88 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package me.thenano.yamibo.yamibo_app.profile.settings.access
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
+import platform.UserNotifications.UNAuthorizationStatusAuthorized
+import platform.UserNotifications.UNAuthorizationStatusDenied
+import platform.UserNotifications.UNAuthorizationStatusProvisional
+import platform.UserNotifications.UNUserNotificationCenter
+import kotlin.coroutines.resume
 
 class IOSBackgroundAccessRepository : BackgroundAccessRepository {
-    private val _state = MutableStateFlow(
-        BackgroundAccessRepository.SetupState(
-            summary = text("iOS 目前沒有 Android 那種常駐前景通知與長時間背景同步能力。"),
-            items = listOf(
-                BackgroundAccessRepository.SetupItem(
-                    title = text("平台限制"),
-                    subtitle = text("iOS 最多只能在進入背景後維持一小段時間執行。若系統掛起 App，收藏同步仍可能中斷。"),
-                    status = BackgroundAccessRepository.SetupStatus.Info,
-                ),
-            ),
-            platformNote = text("這個頁面在 iOS 主要是說明限制，不提供 Android 式的系統授權捷徑。"),
-        ),
-    )
-
+    private val _state = MutableStateFlow(buildState(notificationGranted = null, notificationDenied = false))
     override val state: StateFlow<BackgroundAccessRepository.SetupState> = _state
 
-    override suspend fun refresh() = Unit
+    override suspend fun refresh() {
+        val status = suspendCancellableCoroutine { continuation ->
+            UNUserNotificationCenter.currentNotificationCenter()
+                .getNotificationSettingsWithCompletionHandler { settings ->
+                    if (continuation.isActive) continuation.resume(settings?.authorizationStatus)
+                }
+        }
+        _state.value = buildState(
+            notificationGranted = status == UNAuthorizationStatusAuthorized ||
+                status == UNAuthorizationStatusProvisional,
+            notificationDenied = status == UNAuthorizationStatusDenied,
+        )
+    }
 
-    override fun runAction(action: BackgroundAccessRepository.SetupAction) = Unit
+    override fun runAction(action: BackgroundAccessRepository.SetupAction) {
+        if (
+            action == BackgroundAccessRepository.SetupAction.OpenNotificationSettings ||
+            action == BackgroundAccessRepository.SetupAction.OpenAppSettings
+        ) {
+            NSURL.URLWithString(UIApplicationOpenSettingsURLString)?.let {
+                UIApplication.sharedApplication.openURL(it)
+            }
+        }
+    }
+
+    private fun buildState(
+        notificationGranted: Boolean?,
+        notificationDenied: Boolean,
+    ): BackgroundAccessRepository.SetupState = BackgroundAccessRepository.SetupState(
+        summary = when (notificationGranted) {
+            true -> text("通知權限已允許；iOS 會依系統排程執行背景檢查。")
+            false -> text("通知權限尚未允許，系統無法顯示新消息通知。")
+            null -> text("正在檢查 iOS 通知權限。")
+        },
+        items = listOf(
+            BackgroundAccessRepository.SetupItem(
+                title = text("通知權限"),
+                subtitle = text("允許 App 在發現首頁消息紅點時顯示通知。"),
+                status = if (notificationGranted == true) {
+                    BackgroundAccessRepository.SetupStatus.Granted
+                } else {
+                    BackgroundAccessRepository.SetupStatus.Required
+                },
+                actionLabel = if (notificationGranted == true) null else {
+                    text(if (notificationDenied) "開啟系統設定" else "允許通知")
+                },
+                action = if (notificationGranted == true) null else {
+                    if (notificationDenied) {
+                        BackgroundAccessRepository.SetupAction.OpenNotificationSettings
+                    } else {
+                        BackgroundAccessRepository.SetupAction.RequestNotificationPermission
+                    }
+                },
+            ),
+            BackgroundAccessRepository.SetupItem(
+                title = text("背景刷新由系統安排"),
+                subtitle = text("iOS 不保證精確的檢查時間；低耗電模式、使用習慣與系統資源都可能延後刷新。"),
+                status = BackgroundAccessRepository.SetupStatus.Info,
+            ),
+        ),
+        platformNote = text("iOS 的背景刷新屬於 best-effort；選擇的週期是最早可執行時間，不是準時保證。"),
+    )
 
     private companion object {
         fun text(source: String, vararg args: Any?): BackgroundAccessRepository.I18nText =
             BackgroundAccessRepository.I18nText(source = source, args = args.toList())
     }
 }
-

--- a/i18n/base.csv
+++ b/i18n/base.csv
@@ -929,3 +929,14 @@ RSS 目錄進度,RSS catalog progress,RSS 目錄進度,RSS 目录进度
 安全載入完成，套用 {} 筆操作；保留 {} 筆無法解析來源的舊 RSS 閱讀紀錄於本機,"Safe load completed with {} operation(s); {} unresolved legacy RSS reading record(s) remain local",安全載入完成，套用 {} 筆操作；保留 {} 筆無法解析來源的舊 RSS 閱讀紀錄於本機,安全加载完成，应用 {} 条操作；{} 条无法解析来源的旧 RSS 阅读记录保留在本地
 閱讀時間,Reading time,閱讀時間,阅读时间
 關閉 {},Disabled {},關閉 {},关闭 {}
+新消息通知,New message notifications,新消息通知,新消息通知
+定時檢查新消息,Check for new messages periodically,定時檢查新消息,定时检查新消息
+在背景讀取首頁的消息紅點，發現新消息時顯示系統通知。,Read the homepage message indicator in the background and show a system notification when new messages are present.,在背景讀取首頁的消息紅點，發現新消息時顯示系統通知。,在后台读取首页的消息红点，发现新消息时显示系统通知。
+檢查週期,Check interval,檢查週期,检查周期
+每日通知次數上限,Daily notification limit,每日通知次數上限,每日通知次数上限
+無上限,Unlimited,無上限,无上限
+通知內容不包含消息正文；iOS 的實際檢查時間由系統決定。,Notifications do not include message content; iOS determines the actual check time.,通知內容不包含消息正文；iOS 的實際檢查時間由系統決定。,通知内容不包含消息正文；iOS 的实际检查时间由系统决定。
+系統存取狀態,System access status,系統存取狀態,系统访问状态
+查看通知,View messages,查看通知,查看通知
+不再提醒（僅限今日）,Do not remind again today,不再提醒（僅限今日）,不再提醒（仅限今日）
+您有新的通知，快來看看吧 !,"You have a new notification. Come take a look!",您有新的通知，快來看看吧 !,您有新的通知，快来看看吧 !

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -7,10 +7,12 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>me.thenano.yamibo.yamibo-app.app-sync</string>
+		<string>me.thenano.yamibo.yamibo-app.message-notification</string>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>processing</string>
+		<string>fetch</string>
 	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,12 +2,63 @@ import SwiftUI
 import BackgroundTasks
 import ComposeApp
 import UIKit
+import UserNotifications
+
+private final class MessageNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        switch response.actionIdentifier {
+        case IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_MUTE_ACTION_IDENTIFIER:
+            IOSMessageNotificationBackgroundKt.muteMessageNotificationsToday { _ in
+                completionHandler()
+            }
+        case IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_OPEN_ACTION_IDENTIFIER,
+             UNNotificationDefaultActionIdentifier:
+            IOSMessageNotificationBackgroundKt.openMessageCenterFromIOSNotification()
+            completionHandler()
+        default:
+            completionHandler()
+        }
+    }
+}
 
 @main
 struct iOSApp: App {
     @Environment(\.scenePhase) private var scenePhase
+    private let messageNotificationDelegate = MessageNotificationDelegate()
 
     init() {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = messageNotificationDelegate
+        let open = UNNotificationAction(
+            identifier: IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_OPEN_ACTION_IDENTIFIER,
+            title: "查看通知",
+            options: [.foreground]
+        )
+        let mute = UNNotificationAction(
+            identifier: IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_MUTE_ACTION_IDENTIFIER,
+            title: "不再提醒（僅限今日）",
+            options: []
+        )
+        center.setNotificationCategories([
+            UNNotificationCategory(
+                identifier: IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_CATEGORY_IDENTIFIER,
+                actions: [open, mute],
+                intentIdentifiers: [],
+                options: []
+            )
+        ])
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: IOSAppSyncBackgroundKt.APP_SYNC_BACKGROUND_TASK_IDENTIFIER,
             using: nil
@@ -27,6 +78,27 @@ struct iOSApp: App {
                 guard !completed else { return }
                 completed = true
                 processingTask.setTaskCompleted(success: success.boolValue)
+            }
+        }
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: IOSMessageNotificationBackgroundKt.MESSAGE_NOTIFICATION_BACKGROUND_TASK_IDENTIFIER,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            var completed = false
+            refreshTask.expirationHandler = {
+                guard !completed else { return }
+                completed = true
+                IOSMessageNotificationBackgroundKt.cancelMessageNotificationBackground()
+                refreshTask.setTaskCompleted(success: false)
+            }
+            IOSMessageNotificationBackgroundKt.runMessageNotificationBackground { success in
+                guard !completed else { return }
+                completed = true
+                refreshTask.setTaskCompleted(success: success.boolValue)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationChecker.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationChecker.kt
@@ -1,0 +1,71 @@
+package me.thenano.yamibo.yamibo_app.repository.notification
+
+import io.github.littlesurvival.core.YamiboResult
+import io.github.littlesurvival.dto.page.HomePage
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import me.thenano.yamibo.yamibo_app.repository.settings.AppSettingsRepository
+import me.thenano.yamibo.yamibo_app.util.time.currentLocalDateKey
+
+class MessageNotificationChecker(
+    private val settings: AppSettingsRepository,
+    private val deliveryStateStore: MessageNotificationDeliveryStateStore,
+    private val currentUserId: () -> Int?,
+    private val fetchHomePage: suspend () -> YamiboResult<HomePage>,
+    private val notificationGateway: MessageNotificationGateway,
+    private val currentDate: () -> String = ::currentLocalDateKey,
+) {
+    sealed interface Result {
+        data object Disabled : Result
+        data object MissingAccount : Result
+        data object NoNewMessage : Result
+        data object MutedToday : Result
+        data object DailyLimitReached : Result
+        data object Delivered : Result
+        data object DeliveryUnavailable : Result
+        data class FetchFailed(val retryable: Boolean) : Result
+    }
+
+    private val mutex = Mutex()
+
+    suspend fun check(): Result = mutex.withLock {
+        if (!settings.messageNotificationEnabled.getValue()) return@withLock Result.Disabled
+        val userId = currentUserId() ?: return@withLock Result.MissingAccount
+        val homePage = when (val result = fetchHomePage()) {
+            is YamiboResult.Success -> result.value
+            is YamiboResult.Failure -> return@withLock Result.FetchFailed(retryable = true)
+            is YamiboResult.WafChallenge,
+            YamiboResult.Maintenance,
+            YamiboResult.NotLoggedIn,
+            is YamiboResult.NoPermission,
+            -> return@withLock Result.FetchFailed(retryable = false)
+        }
+        if (!homePage.hasNewMessage) return@withLock Result.NoNewMessage
+
+        val today = currentDate()
+        val dailyState = deliveryStateStore.stateFor(userId, today)
+        if (dailyState.muted) return@withLock Result.MutedToday
+        val limit = settings.messageNotificationDailyLimit.getValue().maxPerDay
+        if (limit != null && dailyState.deliveredCount >= limit) {
+            return@withLock Result.DailyLimitReached
+        }
+        if (!notificationGateway.showMessageNotification()) {
+            return@withLock Result.DeliveryUnavailable
+        }
+        deliveryStateStore.recordDelivery(userId, today)
+        Result.Delivered
+    }
+
+    suspend fun muteToday(): Boolean = mutex.withLock {
+        val userId = currentUserId()
+        if (userId != null) deliveryStateStore.muteToday(userId, currentDate())
+        notificationGateway.dismissMessageNotification()
+        userId != null
+    }
+}
+
+interface MessageNotificationGateway {
+    suspend fun showMessageNotification(): Boolean
+
+    suspend fun dismissMessageNotification()
+}

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationDeliveryStateStore.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationDeliveryStateStore.kt
@@ -1,0 +1,48 @@
+package me.thenano.yamibo.yamibo_app.repository.notification
+
+import me.thenano.yamibo.yamibo_app.store.settings.SettingsStore
+
+class MessageNotificationDeliveryStateStore(
+    private val settingsStore: SettingsStore,
+) {
+    data class DailyState(
+        val deliveredCount: Int,
+        val muted: Boolean,
+    )
+
+    fun stateFor(userId: Int, localDate: String): DailyState {
+        val prefix = keyPrefix(userId)
+        val deliveryDate = settingsStore.getString("$prefix.delivery_date", "")
+        val deliveredCount = if (deliveryDate == localDate) {
+            settingsStore.getInt("$prefix.delivery_count", 0).coerceAtLeast(0)
+        } else {
+            0
+        }
+        return DailyState(
+            deliveredCount = deliveredCount,
+            muted = settingsStore.getString("$prefix.muted_date", "") == localDate,
+        )
+    }
+
+    fun recordDelivery(userId: Int, localDate: String) {
+        val prefix = keyPrefix(userId)
+        val previousDate = settingsStore.getString("$prefix.delivery_date", "")
+        val previousCount = if (previousDate == localDate) {
+            settingsStore.getInt("$prefix.delivery_count", 0).coerceAtLeast(0)
+        } else {
+            0
+        }
+        settingsStore.putString("$prefix.delivery_date", localDate)
+        settingsStore.putInt("$prefix.delivery_count", previousCount + 1)
+    }
+
+    fun muteToday(userId: Int, localDate: String) {
+        settingsStore.putString("${keyPrefix(userId)}.muted_date", localDate)
+    }
+
+    private fun keyPrefix(userId: Int): String = "$KEY_PREFIX.$userId"
+
+    private companion object {
+        const val KEY_PREFIX = "message_notifications.runtime"
+    }
+}

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepository.kt
@@ -130,6 +130,32 @@ enum class SignReminderFrequency(val label: String, val timesPerDay: Int) {
     SIX_TIMES_A_DAY("6x_day", 6),
 }
 
+enum class MessageNotificationDailyLimit(
+    val label: String,
+    val maxPerDay: Int?,
+) {
+    ONCE("1x_day", 1),
+    TWICE("2x_day", 2),
+    THREE_TIMES("3x_day", 3),
+    FOUR_TIMES("4x_day", 4),
+    FIVE_TIMES("5x_day", 5),
+    SIX_TIMES("6x_day", 6),
+    UNLIMITED("unlimited", null),
+}
+
+val MessageNotificationIntervals: List<FixedScheduleInterval> = listOf(
+    FixedScheduleInterval.Hours1,
+    FixedScheduleInterval.Hours2,
+    FixedScheduleInterval.Hours3,
+    FixedScheduleInterval.Hours4,
+    FixedScheduleInterval.Hours6,
+    FixedScheduleInterval.Hours12,
+    FixedScheduleInterval.Days1,
+    FixedScheduleInterval.Days2,
+    FixedScheduleInterval.Days3,
+    FixedScheduleInterval.Week1,
+)
+
 enum class AppLanguage(val label: String, val languageTag: String) {
     TRADITIONAL_CHINESE("zh-TW", "zh-TW"),
     SIMPLIFIED_CHINESE("zh-CN", "zh-CN"),
@@ -172,6 +198,24 @@ class AppSettingsRepository(store: SettingsStore) : SettingsRegistry(store, pref
     val showHomeSwiperImages by boolSetting(
         name = "show_home_swiper_images",
         default = true,
+    )
+
+    /** 定期檢查首頁新消息 */
+    val messageNotificationEnabled by boolSetting(
+        name = "message_notification_enabled",
+        default = true,
+    )
+
+    /** 首頁新消息檢查週期 */
+    val messageNotificationInterval by enumSetting(
+        name = "message_notification_interval",
+        default = FixedScheduleInterval.Hours3,
+    )
+
+    /** 每日首頁新消息通知上限 */
+    val messageNotificationDailyLimit by enumSetting(
+        name = "message_notification_daily_limit",
+        default = MessageNotificationDailyLimit.TWICE,
     )
 
     /** App 字體 */
@@ -379,6 +423,7 @@ class AppSettingsRepository(store: SettingsStore) : SettingsRegistry(store, pref
         val backupIntervalOptions = BackupInterval.entries.map { it to it.label }
         val signInModeOptions = SignInMode.entries.map { it to it.label }
         val signInReminderFrequencyOptions = SignReminderFrequency.entries.map { it to it.label }
+        val messageNotificationDailyLimitOptions = MessageNotificationDailyLimit.entries.map { it to it.label }
         val languageOptions = AppLanguage.entries.map { it to it.label }
     }
 }

--- a/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationCheckerTest.kt
+++ b/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/notification/MessageNotificationCheckerTest.kt
@@ -1,0 +1,178 @@
+package me.thenano.yamibo.yamibo_app.repository.notification
+
+import io.github.littlesurvival.core.YamiboResult
+import io.github.littlesurvival.dto.page.HomePage
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import me.thenano.yamibo.yamibo_app.repository.settings.AppSettingsRepository
+import me.thenano.yamibo.yamibo_app.repository.settings.MessageNotificationDailyLimit
+import me.thenano.yamibo.yamibo_app.store.settings.SettingsStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MessageNotificationCheckerTest {
+    @Test
+    fun positiveHomepageHonorsQuotaAndResetsOnNextDate() = runBlocking {
+        val fixture = Fixture()
+
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        assertEquals(MessageNotificationChecker.Result.DailyLimitReached, fixture.checker.check())
+        assertEquals(2, fixture.gateway.showCount)
+
+        fixture.today = "2026-08-28"
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        assertEquals(3, fixture.gateway.showCount)
+    }
+
+    @Test
+    fun falseAndFailedHomepageDoNotConsumeQuota() = runBlocking {
+        val fixture = Fixture()
+        fixture.homeResult = YamiboResult.Success(homePage(hasNewMessage = false))
+        assertEquals(MessageNotificationChecker.Result.NoNewMessage, fixture.checker.check())
+        fixture.homeResult = YamiboResult.Failure("offline")
+        assertEquals(MessageNotificationChecker.Result.FetchFailed(retryable = true), fixture.checker.check())
+        fixture.homeResult = YamiboResult.Maintenance
+        assertEquals(MessageNotificationChecker.Result.FetchFailed(retryable = false), fixture.checker.check())
+        fixture.homeResult = YamiboResult.Success(homePage(hasNewMessage = true))
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        assertEquals(1, fixture.gateway.showCount)
+    }
+
+    @Test
+    fun disabledAndMissingAccountAvoidHomepageFetch() = runBlocking {
+        val fixture = Fixture()
+        fixture.settings.messageNotificationEnabled.setValue(false)
+        assertEquals(MessageNotificationChecker.Result.Disabled, fixture.checker.check())
+        assertEquals(0, fixture.fetchCount)
+
+        fixture.settings.messageNotificationEnabled.setValue(true)
+        fixture.userId = null
+        assertEquals(MessageNotificationChecker.Result.MissingAccount, fixture.checker.check())
+        assertEquals(0, fixture.fetchCount)
+    }
+
+    @Test
+    fun unlimitedModeAllowsEveryPositiveCheck() = runBlocking {
+        val fixture = Fixture()
+        fixture.settings.messageNotificationDailyLimit.setValue(MessageNotificationDailyLimit.UNLIMITED)
+
+        repeat(8) {
+            assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        }
+        assertEquals(8, fixture.gateway.showCount)
+    }
+
+    @Test
+    fun muteIsPerAccountAndExpiresOnNextDate() = runBlocking {
+        val fixture = Fixture()
+
+        assertTrue(fixture.checker.muteToday())
+        assertEquals(1, fixture.gateway.dismissCount)
+        assertEquals(MessageNotificationChecker.Result.MutedToday, fixture.checker.check())
+
+        fixture.userId = 22
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        fixture.userId = 11
+        fixture.today = "2026-08-28"
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+    }
+
+    @Test
+    fun failedPostingDoesNotConsumeQuota() = runBlocking {
+        val fixture = Fixture()
+        fixture.gateway.canShow = false
+
+        repeat(3) {
+            assertEquals(MessageNotificationChecker.Result.DeliveryUnavailable, fixture.checker.check())
+        }
+        fixture.gateway.canShow = true
+        assertEquals(MessageNotificationChecker.Result.Delivered, fixture.checker.check())
+        assertEquals(4, fixture.gateway.showCount)
+    }
+
+    @Test
+    fun concurrentChecksAreSerializedAcrossPostingAndAccounting() = runBlocking {
+        val fixture = Fixture()
+        fixture.settings.messageNotificationDailyLimit.setValue(MessageNotificationDailyLimit.ONCE)
+        fixture.gateway.delayMillis = 20
+
+        val results = List(4) { async { fixture.checker.check() } }.awaitAll()
+
+        assertEquals(1, results.count { it == MessageNotificationChecker.Result.Delivered })
+        assertEquals(3, results.count { it == MessageNotificationChecker.Result.DailyLimitReached })
+        assertEquals(1, fixture.gateway.showCount)
+    }
+
+    @Test
+    fun muteWithoutAccountStillDismissesVisibleNotification() = runBlocking {
+        val fixture = Fixture()
+        fixture.userId = null
+
+        assertFalse(fixture.checker.muteToday())
+        assertEquals(1, fixture.gateway.dismissCount)
+    }
+
+    private class Fixture {
+        val store = MemorySettingsStore()
+        val settings = AppSettingsRepository(store)
+        val gateway = FakeGateway()
+        var today = "2026-08-27"
+        var userId: Int? = 11
+        var fetchCount = 0
+        var homeResult: YamiboResult<HomePage> = YamiboResult.Success(homePage(hasNewMessage = true))
+        val checker = MessageNotificationChecker(
+            settings = settings,
+            deliveryStateStore = MessageNotificationDeliveryStateStore(store),
+            currentUserId = { userId },
+            fetchHomePage = {
+                fetchCount += 1
+                homeResult
+            },
+            notificationGateway = gateway,
+            currentDate = { today },
+        )
+    }
+
+    private class FakeGateway : MessageNotificationGateway {
+        var canShow = true
+        var showCount = 0
+        var dismissCount = 0
+        var delayMillis = 0L
+
+        override suspend fun showMessageNotification(): Boolean {
+            showCount += 1
+            if (delayMillis > 0) delay(delayMillis)
+            return canShow
+        }
+
+        override suspend fun dismissMessageNotification() {
+            dismissCount += 1
+        }
+    }
+}
+
+private fun homePage(hasNewMessage: Boolean): HomePage = HomePage(
+    swiperImages = emptyList(),
+    categories = emptyList(),
+    hasNewMessage = hasNewMessage,
+)
+
+private class MemorySettingsStore : SettingsStore {
+    private val values = mutableMapOf<String, String>()
+
+    override fun getInt(key: String, defaultValue: Int): Int = values[key]?.toIntOrNull() ?: defaultValue
+    override fun putInt(key: String, value: Int) { values[key] = value.toString() }
+    override fun getFloat(key: String, defaultValue: Float): Float = values[key]?.toFloatOrNull() ?: defaultValue
+    override fun putFloat(key: String, value: Float) { values[key] = value.toString() }
+    override fun getString(key: String, defaultValue: String): String = values[key] ?: defaultValue
+    override fun putString(key: String, value: String) { values[key] = value }
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = values[key]?.toBooleanStrictOrNull() ?: defaultValue
+    override fun putBoolean(key: String, value: Boolean) { values[key] = value.toString() }
+    override fun remove(key: String) { values.remove(key) }
+    override fun hasKey(key: String): Boolean = key in values
+}

--- a/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/AppSettingsRepositoryTest.kt
@@ -51,6 +51,19 @@ class AppSettingsRepositoryTest {
         assertEquals(FixedScheduleInterval.Hours24, AppUpdateLaunchCheckThreshold.HOURS_24.fixedInterval)
         assertEquals(FixedScheduleInterval.Week1, BackupInterval.WEEK_1.fixedInterval)
     }
+
+    @Test
+    fun messageNotificationsDefaultEnabledAtThreeHoursAndTwiceDaily() {
+        val repository = AppSettingsRepository(AppSettingsMemoryStore())
+
+        assertTrue(repository.messageNotificationEnabled.getValue())
+        assertEquals(FixedScheduleInterval.Hours3, repository.messageNotificationInterval.getValue())
+        assertEquals(MessageNotificationDailyLimit.TWICE, repository.messageNotificationDailyLimit.getValue())
+        assertEquals((1..6).toList(), MessageNotificationDailyLimit.entries.mapNotNull { it.maxPerDay })
+        assertEquals(null, MessageNotificationDailyLimit.UNLIMITED.maxPerDay)
+        assertEquals(10, MessageNotificationIntervals.size)
+        assertTrue(FixedScheduleInterval.Hours3 in MessageNotificationIntervals)
+    }
 }
 
 private class AppSettingsMemoryStore : SettingsStore {


### PR DESCRIPTION
## Problem and root cause

The profile badge already detects new messages from HomePage.hasNewMessage, but that check only runs while the home/profile UI is active. There was no durable background schedule or platform notification path, so users could not be alerted while the app was suspended.

## Implementation and design decisions

- Added persisted settings under Settings > Notifications & Background Sync: enabled, fixed check interval, and per-day limit.
- Defaults are enabled, three hours, and two notifications per local day. Limits support one through six or unlimited.
- Reuses the homepage hasNewMessage signal; it does not fetch message bodies or mutate read state.
- Keeps delivery count and today-only mute device-local and keyed by account/date.
- Android uses one unique WorkManager periodic request with connected-network and battery-not-low constraints.
- Android notification uses a dedicated channel/ID, fixed Chinese body, View notifications action, and Do not remind again today action.
- Notification taps route through a shared one-shot trigger to the private-message tab for warm and cold starts.
- iOS uses a dedicated best-effort BGAppRefreshTask, local notification category/actions, and notification authorization diagnostics.
- Reused existing fixed interval labels, wrapping SettingsChipRow, and shared toggle styling.

## User-visible behavior

When an authenticated scheduled homepage fetch reports the existing message red dot, the app posts: 您有新的通知，快來看看吧 !

The user can open the private-message tab or mute further reminders for the current local day. A persistent red dot may remind again until the configured daily limit is reached. Failed fetches or failed notification delivery consume no quota.

## Verification

- shared:testDebugUnitTest passed.
- composeApp:testDebugUnitTest passed.
- Android debug Kotlin compilation and install passed.
- iOS Simulator Kotlin compilation passed.
- Emulator QA verified defaults, option persistence, unique schedule updates/cancellation, constraints, permission denial, actual notification content/actions, today-only mute, warm/cold navigation, and a cold-started worker SUCCESS result.
- Emulator crash buffer remained empty.
- git diff --check passed.
- OpenSpec change and full OpenSpec tree validation passed before integration.
- OpenSpec isolation guard: git diff --name-only main...HEAD -- openspec/ is empty.

## Risks, limits, and rollback

- Android and iOS schedule timing is OS-controlled; iOS is explicitly best-effort and force-quit can suppress launches.
- A persistent homepage red dot can produce repeated reminders up to the configured limit by design.
- iOS framework compilation passed on Windows cross-compilation, but Xcode signing, physical-device background timing, and notification action behavior still require Apple-host/device validation.
- Rollback is the single feature commit; disabling the setting cancels the unique schedule. Device-local runtime keys are harmless if left unused.

OpenSpec planning artifacts and the unrelated staged update/changelogs/8.changelog are intentionally excluded from this PR.