### PR TITLE
feat(reader): add default bold and italic settings

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/SettingsCategoryScreen.kt
@@ -184,6 +184,11 @@ private fun NovelReaderContent() {
     ReaderFontSelectorSetting()
     Spacer(Modifier.height(24.dp))
 
+    SectionLabel(i18n("字體樣式"))
+    NovelDefaultBoldSetting()
+    NovelDefaultItalicSetting()
+    Spacer(Modifier.height(24.dp))
+
     SectionLabel(i18n("內容寬度"))
     NovelContentWidthSetting()
     Spacer(Modifier.height(24.dp))

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/bound/BoundNovelSettings.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/profile/settings/bound/BoundNovelSettings.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.sp
 import me.thenano.yamibo.yamibo_app.LocalNovelReaderSettingsRepository
 import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsChipRow
 import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsSlider
+import me.thenano.yamibo.yamibo_app.profile.settings.components.SettingsToggleRow
 import me.thenano.yamibo.yamibo_app.repository.settings.ReaderChineseConversionOption
 import me.thenano.yamibo.yamibo_app.repository.settings.ReaderScrollButtonDisplayMode
 import me.thenano.yamibo.yamibo_app.repository.settings.ReaderScrollButtonJumpTarget
@@ -92,6 +93,32 @@ fun NovelLineSpacingSetting() {
         steps = 39,
         valueDisplay = { "${(it * 100f).roundToInt() / 100f}x" },
         onValueChange = { novelSettingsRepo.lineSpacing.setValue(it) }
+    )
+}
+
+@Composable
+fun NovelDefaultBoldSetting() {
+    val novelSettingsRepo = LocalNovelReaderSettingsRepository.current
+    val enabled = novelSettingsRepo.defaultBold.state()
+
+    SettingsToggleRow(
+        title = i18n("預設粗體"),
+        subtitle = i18n("將閱讀器正文預設顯示為粗體"),
+        checked = enabled,
+        onCheckedChange = { novelSettingsRepo.defaultBold.setValue(it) },
+    )
+}
+
+@Composable
+fun NovelDefaultItalicSetting() {
+    val novelSettingsRepo = LocalNovelReaderSettingsRepository.current
+    val enabled = novelSettingsRepo.defaultItalic.state()
+
+    SettingsToggleRow(
+        title = i18n("預設斜體"),
+        subtitle = i18n("將閱讀器正文預設顯示為斜體"),
+        checked = enabled,
+        onCheckedChange = { novelSettingsRepo.defaultItalic.setValue(it) },
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/components/novel/NovelReaderSettingsPanel.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/components/novel/NovelReaderSettingsPanel.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.sp
 import me.thenano.yamibo.yamibo_app.repository.settings.AppSettingsRepository
 import me.thenano.yamibo.yamibo_app.profile.settings.components.ThemeSelectorContent
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelChineseConversionSetting
+import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelDefaultBoldSetting
+import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelDefaultItalicSetting
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelFontSizeSetting
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelLineSpacingSetting
 import me.thenano.yamibo.yamibo_app.profile.settings.bound.NovelPageProgressHintSetting
@@ -85,6 +87,11 @@ fun NovelReaderSettingsPanel(
 
                     Spacer(Modifier.height(16.dp))
                     ReaderFontSelectorSetting()
+
+                    Spacer(Modifier.height(8.dp))
+                    NovelDefaultBoldSetting()
+
+                    NovelDefaultItalicSetting()
 
                     Spacer(Modifier.height(16.dp))
                     NovelSystemBarsBackgroundSetting()

--- a/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/components/post/impl/HtmlRenderer.kt
+++ b/composeApp/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/thread/reader/components/post/impl/HtmlRenderer.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
@@ -419,6 +420,8 @@ private fun RubyTextBlock(
     fontSizeSp: Float,
     lineHeightSp: Float,
     textColor: Color,
+    fontWeight: FontWeight,
+    fontStyle: FontStyle,
     modifier: Modifier = Modifier,
     onTextLayout: (TextLayoutResult) -> Unit,
 ) {
@@ -428,20 +431,24 @@ private fun RubyTextBlock(
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
     val rubyFontSizeSp = fontSizeSp * 0.72f
-    val baseStyle = remember(fontFamily, fontSizeSp, textColor) {
+    val baseStyle = remember(fontFamily, fontSizeSp, textColor, fontWeight, fontStyle) {
         TextStyle(
             color = textColor,
             fontFamily = fontFamily,
             fontSize = fontSizeSp.sp,
             lineHeight = fontSizeSp.sp,
+            fontWeight = fontWeight,
+            fontStyle = fontStyle,
         )
     }
-    val rubyStyle = remember(fontFamily, rubyFontSizeSp, textColor) {
+    val rubyStyle = remember(fontFamily, rubyFontSizeSp, textColor, fontWeight, fontStyle) {
         TextStyle(
             color = textColor,
             fontFamily = fontFamily,
             fontSize = rubyFontSizeSp.sp,
             lineHeight = rubyFontSizeSp.sp,
+            fontWeight = fontWeight,
+            fontStyle = fontStyle,
         )
     }
 
@@ -518,6 +525,8 @@ private fun RubyTextBlock(
                 fontFamily = fontFamily,
                 fontSize = fontSizeSp.sp,
                 lineHeight = lineHeightSp.sp,
+                fontWeight = fontWeight,
+                fontStyle = fontStyle,
                 textAlign = textAlign,
             ),
             modifier = Modifier.fillMaxWidth(),
@@ -553,6 +562,10 @@ private fun HtmlBlockRenderer(
     val novelSettingsRepo = LocalNovelReaderSettingsRepository.current
     val fontSize = novelSettingsRepo.fontSize.state()
     val lineSpacing = novelSettingsRepo.lineSpacing.state()
+    val defaultBold = novelSettingsRepo.defaultBold.state()
+    val defaultItalic = novelSettingsRepo.defaultItalic.state()
+    val defaultFontWeight = if (defaultBold) FontWeight.Bold else FontWeight.Normal
+    val defaultFontStyle = if (defaultItalic) FontStyle.Italic else FontStyle.Normal
     @Suppress("DEPRECATION") val clipboardManager = LocalClipboardManager.current
     val isDarkTheme = (colors.creamBackground.red + colors.creamBackground.green + colors.creamBackground.blue) < 1.5f
 
@@ -714,6 +727,8 @@ private fun HtmlBlockRenderer(
                     fontSizeSp = fontSize.toFloat(),
                     lineHeightSp = lineHeightSp,
                     textColor = colors.htmlTextDark,
+                    fontWeight = defaultFontWeight,
+                    fontStyle = defaultFontStyle,
                     modifier = textModifier,
                     onTextLayout = { layoutResult.value = it },
                 )
@@ -725,6 +740,8 @@ private fun HtmlBlockRenderer(
                         fontFamily = fontFamily,
                         fontSize = fontSize.sp,
                         lineHeight = lineHeightSp.sp,
+                        fontWeight = defaultFontWeight,
+                        fontStyle = defaultFontStyle,
                         textAlign = block.textAlign
                     ),
                     modifier = textModifier,
@@ -1236,7 +1253,8 @@ private fun HtmlBlockRenderer(
                                                                     fontFamily = fontFamily,
                                                                     fontSize = tableFontSize.sp,
                                                                     lineHeight = tableLineHeightSp.sp,
-                                                                    fontWeight = if (cell.isHeader) FontWeight.Bold else FontWeight.Normal,
+                                                                    fontWeight = if (cell.isHeader || defaultBold) FontWeight.Bold else FontWeight.Normal,
+                                                                    fontStyle = defaultFontStyle,
                                                                     textAlign = innerBlock.textAlign
                                                                 )
                                                             )

--- a/i18n/glossary.csv
+++ b/i18n/glossary.csv
@@ -872,3 +872,8 @@ App 啟動時同步,Sync on app start,App 啟動時同步,App 启动时同步
 已選擇下載與備份資料夾,Download and backup folder selected,已選擇下載與備份資料夾,已选择下载与备份文件夹
 無法選擇資料夾,Unable to select folder,無法選擇資料夾,无法选择文件夹
 下載、備份資料夾與緩存清理設定,"Download and backup folder, and cache cleanup settings",下載、備份資料夾與緩存清理設定,下载、备份文件夹与缓存清理设置
+字體樣式,Font style,字體樣式,字体样式
+預設粗體,Default bold,預設粗體,默认粗体
+將閱讀器正文預設顯示為粗體,Show reader body text in bold by default,將閱讀器正文預設顯示為粗體,将阅读器正文默认显示为粗体
+預設斜體,Default italic,預設斜體,默认斜体
+將閱讀器正文預設顯示為斜體,Show reader body text in italic by default,將閱讀器正文預設顯示為斜體,将阅读器正文默认显示为斜体

--- a/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/NovelReaderSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/NovelReaderSettingsRepository.kt
@@ -53,6 +53,18 @@ class NovelReaderSettingsRepository(store: SettingsStore) : SettingsRegistry(sto
         default = "",
     )
 
+    val defaultBold by boolSetting(
+        name = "default_bold",
+        description = "novel_reader_default_bold",
+        default = false,
+    )
+
+    val defaultItalic by boolSetting(
+        name = "default_italic",
+        description = "novel_reader_default_italic",
+        default = false,
+    )
+
     val contentWidthFraction by floatSetting(
         name = "content_width",
         description = "novel_reader_content_width",

--- a/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/NovelReaderTypographySettingsTest.kt
+++ b/shared/src/commonTest/kotlin/me/thenano/yamibo/yamibo_app/repository/settings/NovelReaderTypographySettingsTest.kt
@@ -1,0 +1,46 @@
+package me.thenano.yamibo.yamibo_app.repository.settings
+
+import me.thenano.yamibo.yamibo_app.store.settings.SettingsStore
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NovelReaderTypographySettingsTest {
+    @Test
+    fun defaultTextStylesStartDisabledAndPersistIndependently() {
+        val store = TypographyMemoryStore()
+        val repository = NovelReaderSettingsRepository(store)
+
+        assertFalse(repository.defaultBold.getValue())
+        assertFalse(repository.defaultItalic.getValue())
+        assertFalse(store.hasKey(repository.defaultBold.storageKey))
+        assertFalse(store.hasKey(repository.defaultItalic.storageKey))
+
+        repository.defaultBold.setValue(true)
+        assertTrue(NovelReaderSettingsRepository(store).defaultBold.getValue())
+        assertFalse(NovelReaderSettingsRepository(store).defaultItalic.getValue())
+
+        repository.defaultItalic.setValue(true)
+        val restored = NovelReaderSettingsRepository(store)
+        assertTrue(restored.defaultBold.getValue())
+        assertTrue(restored.defaultItalic.getValue())
+        assertTrue(restored.defaultBold.storageKey in restored.exportableSettingItems.map { it.storageKey })
+        assertTrue(restored.defaultItalic.storageKey in restored.exportableSettingItems.map { it.storageKey })
+    }
+}
+
+private class TypographyMemoryStore : SettingsStore {
+    private val values = mutableMapOf<String, String>()
+
+    override fun getInt(key: String, defaultValue: Int): Int = values[key]?.toIntOrNull() ?: defaultValue
+    override fun putInt(key: String, value: Int) { values[key] = value.toString() }
+    override fun getFloat(key: String, defaultValue: Float): Float = values[key]?.toFloatOrNull() ?: defaultValue
+    override fun putFloat(key: String, value: Float) { values[key] = value.toString() }
+    override fun getString(key: String, defaultValue: String): String = values[key] ?: defaultValue
+    override fun putString(key: String, value: String) { values[key] = value }
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean =
+        values[key]?.toBooleanStrictOrNull() ?: defaultValue
+    override fun putBoolean(key: String, value: Boolean) { values[key] = value.toString() }
+    override fun remove(key: String) { values.remove(key) }
+    override fun hasKey(key: String): Boolean = key in values
+}


### PR DESCRIPTION
## Problem and root cause

The reader supported font size, line spacing, and custom font selection, but had no persisted default style controls. Readers who prefer heavier or italic body text had to rely on source HTML styling, which is inconsistent across posts.

## Implementation and design decisions

- Add independent `defaultBold` and `defaultItalic` boolean settings to `NovelReaderSettingsRepository`.
- Keep both defaults disabled so existing installations retain their current appearance.
- Reuse the same bound setting controls in the full Novel Reader settings screen and the in-reader settings panel.
- Apply the selected defaults to normal HTML body text, Ruby base/annotation text, and table content while preserving source-provided spans.
- Include both settings in the existing registry export/sync path.
- Add Traditional Chinese, Simplified Chinese, and English glossary entries.

## User-visible behavior

Under Settings > Novel Reader > Font style, users can independently enable Default bold and Default italic. Changes update the reader preview immediately and can be combined.

## Verification evidence

- `:shared:testDebugUnitTest --tests '*NovelReaderTypographySettingsTest*'` passed.
- `:composeApp:compileDebugKotlinAndroid` passed.
- `:composeApp:checkI18n` passed.
- `:composeApp:installDebug` installed successfully on `emulator-5554` (Pixel_8_Pro, Android 16).
- Emulator UI-tree checks confirmed both switches transition from unchecked to checked.
- Emulator screenshot confirmed the preview renders combined bold and italic text.
- Force-stop and cold relaunch confirmed both values persist; QA restored both settings to off afterward.
- Post-restart crash buffer and filtered logcat contained no crash, fatal exception, or ANR.
- `git diff --check` passed.
- `git diff --name-only origin/main...HEAD -- openspec/` returned empty.

## Risks, limits, and rollback

- Rendering was verified on Android; iOS compilation/runtime was not exercised in this checkpoint.
- Font appearance still depends on whether the selected font provides native bold/italic faces; Compose may synthesize styles when needed.
- Rollback is the merge commit revert; persisted keys are harmless if the feature is reverted.